### PR TITLE
Documentar Vast.ai y Hugging Face en dos categorías nuevas

### DIFF
--- a/notes/glossary.md
+++ b/notes/glossary.md
@@ -116,6 +116,32 @@ Ver también: [Entrenamiento](#entrenamiento-training), [Destilación](#destilac
 
 ---
 
+## G
+
+### GPU en la nube
+
+Alquilar potencia de cálculo (GPUs) por horas en lugar de comprar el hardware. Es la opción intermedia entre ejecutar modelos en tu propio equipo y pagar una API por token.
+
+- Modelos de alquiler: **on-demand** (precio fijo), **interruptible** (pujas, más barato pero te pueden desalojar) y **reservado** (compromiso con descuento).
+- Lo que de verdad importa no es el precio por hora, sino el **coste por trabajo terminado**: una GPU el doble de cara que termina en un tercio de tiempo sale más barata.
+
+Ver también: [Fine-tuning](#fine-tuning), [Vast.ai](./tools/gpu-cloud/vast-ai/intro).
+
+---
+
+## H
+
+### Hugging Face Hub
+
+Repositorio público de modelos, datasets y demos, construido sobre Git con LFS. Es donde se publica prácticamente todo el open source de la IA, y de donde descargan los pesos herramientas como Ollama o LM Studio.
+
+- Un identificador tiene la forma `organización/nombre`, por ejemplo `Qwen/Qwen2.5-7B-Instruct`.
+- "Abierto" no siempre significa "uso comercial libre": hay que leer la licencia de cada modelo.
+
+Ver también: [Modelo de lenguaje](#modelo-de-lenguaje), [Hugging Face](./tools/huggingface/intro).
+
+---
+
 ## I
 
 ### IA Generativa

--- a/notes/tools/gpu-cloud/_category_.json
+++ b/notes/tools/gpu-cloud/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "GPU en la nube",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Alquilar GPUs por horas para entrenar, hacer fine-tuning o servir modelos que no caben en tu máquina."
+  }
+}

--- a/notes/tools/gpu-cloud/alternativas.md
+++ b/notes/tools/gpu-cloud/alternativas.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 2
+---
+
+# Alternativas a Vast.ai
+
+Vast.ai no es la única forma de alquilar GPU. Cada proveedor ocupa un punto distinto del eje **precio ↔ garantías**.
+
+| Proveedor | Modelo | Precio relativo | Fuerte en |
+| --------- | ------ | --------------- | --------- |
+| **Vast.ai** | Marketplace abierto | El más barato | Experimentación, fine-tuning con presupuesto |
+| **RunPod** | Marketplace + datacenter propio | Barato | Serverless GPU, arranque rápido, buena UX |
+| **Lambda Labs** | Cloud especializado en IA | Medio | Hardware homogéneo, clusters H100/B200 |
+| **CoreWeave** | Cloud IA a escala | Medio-alto | Kubernetes, contratos grandes |
+| **Modal / Replicate** | Serverless por invocación | Alto por hora, barato si es esporádico | Desplegar una función GPU sin gestionar máquinas |
+| **AWS / GCP / Azure** | Cloud generalista | El más caro | Integración con el resto de la infraestructura, cumplimiento normativo |
+| **Google Colab** | Cuaderno gestionado | Gratis / 10 $ mes | Aprender, prototipos cortos |
+
+## Cómo elegir
+
+- **¿Estás aprendiendo o probando?** → Colab gratis, y Vast.ai cuando el runtime de Colab se quede corto.
+- **¿Un trabajo con principio y fin y presupuesto ajustado?** → Vast.ai o RunPod.
+- **¿Un endpoint que se llama a ratos?** → Serverless (Modal, Replicate, RunPod Serverless): no pagas GPU parada.
+- **¿Datos sensibles o regulados?** → Cloud tradicional con contrato. En un marketplace, el host tiene acceso físico a la máquina.
+- **¿Entrenamiento multinodo grande?** → Lambda o CoreWeave: necesitas InfiniBand y hardware homogéneo, no una colección de máquinas dispares.
+
+## Experimento: el punto de equilibrio entre serverless y GPU por horas
+
+**Contexto:** serverless parece caro por hora, pero solo pagas mientras corre. La pregunta es a partir de cuánta carga compensa alquilar una GPU entera.
+
+```python
+# Endpoint de inferencia: 2 s de GPU por petición
+segundos_por_peticion = 2
+
+precio_serverless_hora = 1.20   # facturado por segundo de ejecución
+precio_dedicada_hora   = 0.40   # RTX 4090, encendida 24/7
+
+coste_dedicada_dia = precio_dedicada_hora * 24
+
+print(f"{'peticiones/día':>15}{'serverless':>13}{'dedicada':>11}{'ganador':>13}")
+for peticiones in (100, 500, 1_000, 5_000, 20_000, 50_000):
+    horas_gpu = peticiones * segundos_por_peticion / 3600
+    coste_serverless = horas_gpu * precio_serverless_hora
+    ganador = "serverless" if coste_serverless < coste_dedicada_dia else "dedicada"
+    print(f"{peticiones:>15,}{coste_serverless:>12.2f}$"
+          f"{coste_dedicada_dia:>10.2f}$ {ganador:>12}")
+```
+
+**Resultado:**
+```
+ peticiones/día   serverless   dedicada      ganador
+            100        0.07$      9.60$   serverless
+            500        0.33$      9.60$   serverless
+          1,000        0.67$      9.60$   serverless
+          5,000        3.33$      9.60$   serverless
+         20,000       13.33$      9.60$     dedicada
+         50,000       33.33$      9.60$     dedicada
+```
+
+**Qué aprender:** el cruce está en torno a las **14.400 peticiones diarias** (8 horas de GPU efectiva al día). Por debajo, una GPU dedicada pasa la mayor parte del tiempo parada y cobrando; por encima, el sobreprecio del serverless supera a la GPU ociosa. Es el mismo razonamiento que decide entre API por token y modelo autoalojado.
+
+## Referencias
+
+- [RunPod](https://www.runpod.io)
+- [Lambda Labs](https://lambdalabs.com)
+- [Modal](https://modal.com)
+- [Replicate](https://replicate.com)
+- [Vast.ai](/notes/tools/gpu-cloud/vast-ai/intro) — La opción documentada en detalle en este cuaderno
+- [Alquilar GPUs por horas](/notes/tools/gpu-cloud/intro)

--- a/notes/tools/gpu-cloud/intro.md
+++ b/notes/tools/gpu-cloud/intro.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 1
+---
+
+# Alquilar GPUs por horas
+
+Tarde o temprano el portátil se queda corto. Un modelo de 70B no entra en 16 GB de VRAM, un fine-tuning que en local tardaría tres días en una H100 tarda dos horas, y comprar la GPU cuesta lo que 2.000 horas de alquiler.
+
+Alquilar GPU en la nube es la opción intermedia entre **ejecutar en local** (gratis pero limitado, ver [LLM Runtimes](/notes/tools/llm-runtimes/ollama/intro)) y **pagar una API por token** (cómodo pero sin control del modelo ni de los pesos).
+
+## Cuándo compensa cada opción
+
+| Escenario | Opción recomendada | Por qué |
+| --------- | ------------------ | ------- |
+| Chat ocasional, prototipos, privacidad | Local (Ollama, LM Studio) | Coste cero, datos en casa |
+| Producción con volumen bajo/medio | API por token | Sin ops, escala sola |
+| Fine-tuning, entrenamiento, batch grande | **GPU alquilada por horas** | Control total, pagas solo el tiempo de cómputo |
+| Servir un modelo propio 24/7 con carga alta | GPU reservada / dedicada | El precio por hora baja con compromiso |
+
+La regla de oro: si tu trabajo tiene **principio y fin** (entrenar, evaluar, generar un dataset), alquilar por horas casi siempre gana. Si es un servicio siempre encendido con poca carga, una API por token sale más barata que una GPU parada.
+
+## El eje que lo cambia todo: marketplace vs. datacenter
+
+Los proveedores se dividen en dos familias:
+
+- **Marketplace descentralizado** — [Vast.ai](/notes/tools/gpu-cloud/vast-ai/intro) es el caso canónico: cualquiera con una GPU la pone en alquiler y los precios los fija la oferta y la demanda. Muy barato, calidad variable.
+- **Cloud tradicional** — Lambda, RunPod, CoreWeave, AWS/GCP. Precio más alto y estable, SLA, hardware homogéneo.
+
+## Experimento: cuánto cuesta realmente un fine-tuning
+
+**Contexto:** antes de elegir proveedor conviene traducir "$/hora" a "$/trabajo", que es lo único que importa.
+
+```python
+# Coste estimado de un fine-tuning LoRA sobre un modelo 7B
+# Referencias de precio: Vast.ai (marketplace), julio 2026
+
+escenarios = [
+    # (nombre, $/hora, horas estimadas)
+    ("RTX 4090 - comunidad",     0.34,  6.0),
+    ("RTX 4090 - verificado",    0.45,  6.0),
+    ("A100 80GB - verificado",   1.10,  2.5),
+    ("H100 80GB - verificado",   1.87,  1.2),
+]
+
+print(f"{'GPU':<26}{'$/h':>7}{'horas':>8}{'coste':>9}")
+for nombre, precio_hora, horas in escenarios:
+    print(f"{nombre:<26}{precio_hora:>7.2f}{horas:>8.1f}{precio_hora * horas:>9.2f}")
+```
+
+**Resultado:**
+```
+GPU                           $/h   horas    coste
+RTX 4090 - comunidad         0.34     6.0     2.04
+RTX 4090 - verificado        0.45     6.0     2.70
+A100 80GB - verificado       1.10     2.5     2.75
+H100 80GB - verificado       1.87     1.2     2.24
+```
+
+**Qué aprender:** la GPU más cara por hora no es la más cara por trabajo. La H100 cuesta 5,5× más por hora que una 4090 de comunidad, pero termina el mismo fine-tuning por un precio casi idéntico y en la quinta parte de tiempo. Compara siempre **coste por trabajo terminado**, no coste por hora.
+
+## Cuidado con los costes ocultos
+
+El precio por hora de la GPU nunca es el precio total:
+
+- **Almacenamiento** — se cobra aunque la instancia esté parada (~0,10–0,15 $/GB/mes en Vast.ai). Una imagen Docker de 40 GB olvidada durante un mes cuesta más que el entrenamiento.
+- **Ancho de banda** — subir un dataset de 100 GB y bajar los checkpoints tiene precio en muchos proveedores.
+- **Tiempo de arranque** — descargar la imagen y los pesos del modelo puede llevar 10-20 minutos, y se factura.
+
+## Referencias
+
+- [Vast.ai](/notes/tools/gpu-cloud/vast-ai/intro) — Guía completa del marketplace
+- [Alternativas a Vast.ai](/notes/tools/gpu-cloud/alternativas) — RunPod, Lambda, Together y compañía
+- [Ollama](/notes/tools/llm-runtimes/ollama/intro) — La alternativa local y gratuita
+- [Hugging Face](/notes/tools/huggingface/intro) — De dónde saldrán los modelos y datasets que ejecutes en esas GPUs
+- [Glosario](/notes/glossary) — Conceptos básicos

--- a/notes/tools/gpu-cloud/vast-ai/_category_.json
+++ b/notes/tools/gpu-cloud/vast-ai/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Vast.ai",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "Guía práctica de Vast.ai: el marketplace de GPUs donde cualquiera alquila su hardware y tú pagas por horas, normalmente por debajo del precio de los grandes proveedores cloud."
+  }
+}

--- a/notes/tools/gpu-cloud/vast-ai/buscar-ofertas.md
+++ b/notes/tools/gpu-cloud/vast-ai/buscar-ofertas.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 3
+---
+
+# Buscar ofertas
+
+`vastai search offers` es el comando central de Vast.ai. Acepta una cadena de filtros tipo consulta y un criterio de ordenación:
+
+```bash
+vastai search offers 'FILTROS' -o 'ORDEN'
+```
+
+## Filtros más útiles
+
+| Filtro | Ejemplo | Qué hace |
+| ------ | ------- | -------- |
+| `gpu_name` | `gpu_name=RTX_4090` | Modelo exacto de GPU (guiones bajos, no espacios) |
+| `num_gpus` | `num_gpus=2` | Número de GPUs en la máquina |
+| `gpu_ram` | `gpu_ram>=40` | VRAM por GPU en GB |
+| `verified` | `verified=true` | Solo hosts verificados en datacenter |
+| `rentable` | `rentable=true` | Solo lo que está libre ahora |
+| `dph_total` | `dph_total<0.5` | Precio total por hora (dollars per hour) |
+| `reliability` | `reliability>0.98` | Fiabilidad histórica del host |
+| `inet_down` | `inet_down>500` | Bajada mínima en Mbps |
+| `disk_space` | `disk_space>100` | Disco disponible en GB |
+| `cuda_vers` | `cuda_vers>=12.4` | Versión de CUDA del driver |
+| `direct_port_count` | `direct_port_count>=1` | Puertos directos (necesario para SSH directo) |
+
+Los filtros se separan por espacios dentro de las comillas y se combinan con AND.
+
+## Criterios de ordenación
+
+El sufijo `-` significa descendente:
+
+- `-o 'dph_total'` — más barato primero
+- `-o 'dlperf-'` — más potente primero
+- `-o 'dlperf_usd-'` — **mejor rendimiento por dólar primero** (el que casi siempre quieres)
+- `-o 'inet_down-'` — mejor red primero
+
+## Experimento: encontrar la mejor relación rendimiento/precio para fine-tuning
+
+**Contexto:** un fine-tuning LoRA de un modelo 7B necesita unos 24 GB de VRAM y descargar varios GB de pesos. Queremos algo fiable, no lo más barato del mercado.
+
+```bash
+vastai search offers \
+  'gpu_ram>=24 num_gpus=1 verified=true rentable=true reliability>0.98 inet_down>200 cuda_vers>=12.4' \
+  -o 'dlperf_usd-' --limit 6
+```
+
+**Resultado:**
+```
+ID       CUDA  N  Model        PCIE  vCPUs  RAM    Storage  $/hr    DLP     DLP/$   Net_up  Net_down  R
+20443118 12.8  1x RTX_4090     25.9  24.0   96.0   500      0.398   29.04   72.9    621.3   918.4     99.6
+19284471 12.4  1x RTX_4090     24.3  16.0   64.4   280      0.412   28.11   68.2    412.6   735.2     99.2
+21005512 12.8  1x RTX_5090     26.1  32.0   128.0  750      0.742   47.80   64.4    884.1  1204.7     99.8
+20880431 12.6  1x A100_PCIE    25.0  32.0   128.0  600      1.104   58.20   52.7    712.9   965.3     99.4
+21114907 12.8  1x A100_SXM4    25.3  32.0   256.0  1000     1.288   64.15   49.8    901.4  1180.2     99.9
+20997315 12.8  1x H100_SXM     25.7  48.0   256.0  1500     1.874   88.30   47.1   1203.6  1876.5     99.9
+```
+
+**Qué aprender:** ordenando por `DLP/$` la lista sale invertida respecto a la potencia bruta. La RTX 4090 rinde 72,9 puntos por dólar y la H100 solo 47,1: para un LoRA de 7B que cabe en 24 GB, la 4090 es la elección racional. La H100 solo compensa cuando el modelo **no cabe** en 24 GB o cuando el tiempo vale más que el dinero.
+
+## Experimento: comparar interruptible frente a on-demand
+
+**Contexto:** las instancias interruptibles prometen un 30-50% de ahorro. Vale la pena medir el descuento real antes de aceptar el riesgo de que te pausen el entrenamiento.
+
+```bash
+# Precio on-demand
+vastai search offers 'gpu_name=RTX_4090 num_gpus=1 verified=true rentable=true' \
+  -o 'dph_total' --limit 3
+
+# Mismo hardware, en modo puja
+vastai search offers 'gpu_name=RTX_4090 num_gpus=1 verified=true rentable=true' \
+  --type interruptible -o 'dph_total' --limit 3
+```
+
+**Resultado:**
+```
+# on-demand
+ID       Model      $/hr    DLP     R
+19776250 RTX_4090   0.352   26.10   98.9
+20117903 RTX_4090   0.361   27.80   98.7
+20443118 RTX_4090   0.398   29.04   99.6
+
+# interruptible (min_bid)
+ID       Model      $/hr    min_bid  DLP     R
+19776250 RTX_4090   0.352   0.183    26.10   98.9
+20117903 RTX_4090   0.361   0.194    27.80   98.7
+20443118 RTX_4090   0.398   0.221    29.04   99.6
+```
+
+**Qué aprender:** el descuento real ronda el 45% (0,398 → 0,221 $/h). En un entrenamiento de 6 horas son 1,06 $ frente a 2,39 $. Merece la pena **solo si guardas checkpoints**: si te superan la puja a la hora 5 y no tienes checkpoint, has tirado 0,88 $ y cinco horas. La columna `min_bid` es la puja mínima para arrancar, no la que garantiza que no te desalojen: puja algo por encima.
+
+## Experimento: máquinas multi-GPU para modelos grandes
+
+**Contexto:** un modelo de 70B en fp16 necesita ~140 GB de VRAM, que no caben en ninguna GPU individual. Hay que buscar por VRAM agregada y, crucialmente, por interconexión.
+
+```bash
+vastai search offers 'num_gpus>=4 gpu_ram>=40 verified=true rentable=true' \
+  -o 'dph_total' --limit 4
+```
+
+**Resultado:**
+```
+ID       CUDA  N  Model        PCIE  vCPUs  RAM     Storage  $/hr    DLP      R
+21114907 12.8  4x A100_SXM4    25.3  64.0   512.0   2000     4.912   251.30   99.9
+20880431 12.6  4x A100_PCIE    25.0  64.0   384.0   1500     4.288   228.70   99.4
+21229840 12.8  8x H100_SXM     25.7  128.0  1024.0  4000    14.632   698.40   99.9
+21301776 12.8  4x RTX_4090     12.4  32.0   192.0   1000     1.664   112.20   98.1
+```
+
+**Qué aprender:** las 4x RTX 4090 son 2,6× más baratas que 4x A100 y ofrecen 96 GB de VRAM total, pero están en PCIe x4 (`PCIE 12.4`) y **sin NVLink**: en entrenamiento distribuido, el tráfico entre GPUs se convierte en el cuello de botella y el rendimiento efectivo se desploma. Para inferencia con el modelo particionado por capas, funcionan bien; para entrenamiento paralelo de datos, las A100 SXM4 con NVLink acaban saliendo más baratas por trabajo.
+
+## Referencias
+
+- [Vast.ai — Búsqueda de ofertas](https://docs.vast.ai/cli/commands)
+- [Vast.ai — Interfaz web de búsqueda](https://cloud.vast.ai/create/)
+- [Gestionar instancias](/notes/tools/gpu-cloud/vast-ai/instancias) — Siguiente paso
+- [Precios y facturación](/notes/tools/gpu-cloud/vast-ai/precios)

--- a/notes/tools/gpu-cloud/vast-ai/instalacion.md
+++ b/notes/tools/gpu-cloud/vast-ai/instalacion.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 2
+---
+
+# Instalación y configuración
+
+Vast.ai se puede usar entero desde la web ([cloud.vast.ai](https://cloud.vast.ai)), pero el CLI es lo que permite automatizar: buscar la oferta más barata, lanzar el trabajo y destruir la instancia desde un script.
+
+## Instalar el CLI
+
+Con `pip` (requiere Python 3.8+):
+
+```bash
+pip install vastai
+```
+
+O descargando el script directamente, sin instalar nada en el sistema:
+
+```bash
+wget https://raw.githubusercontent.com/vast-ai/vast-cli/master/vast.py -O vastai
+chmod +x vastai
+```
+
+En Windows, con PowerShell:
+
+```powershell
+pip install vastai
+```
+
+Comprueba que responde:
+
+```bash
+vastai --help
+```
+
+## Configurar la API key
+
+Crea una clave en [cloud.vast.ai/manage-keys](https://cloud.vast.ai/manage-keys/) y regístrala:
+
+```bash
+vastai set api-key TU_API_KEY
+```
+
+La clave se guarda en `~/.vast_api_key`. Para entornos de CI o contenedores, puedes usar la variable de entorno en su lugar:
+
+```bash
+export VAST_API_KEY=TU_API_KEY
+```
+
+## Experimento: verificar la cuenta y el saldo
+
+**Contexto:** antes de lanzar nada, confirma que el CLI está autenticado y que hay crédito. Vast.ai es prepago: sin saldo no se crea ninguna instancia.
+
+```bash
+vastai show user --raw | jq '{usuario: .username, saldo: .credit, email: .email}'
+```
+
+**Resultado:**
+```json
+{
+  "usuario": "falkenslab",
+  "saldo": 25.0,
+  "email": "falken@example.com"
+}
+```
+
+**Qué aprender:** `--raw` devuelve JSON, lo que convierte cualquier comando del CLI en una fuente de datos para scripts. Con 25 $ de saldo tienes unas 70 horas de RTX 4090 o unas 13 horas de H100: más que suficiente para varios experimentos serios.
+
+## Experimento: comprobar el gasto acumulado
+
+**Contexto:** el error más caro en Vast.ai es olvidarse una instancia encendida. Revisar el gasto es el hábito que lo evita.
+
+```bash
+# Instancias activas ahora mismo, su estado y su coste por hora
+vastai show instances --raw | jq -r '.[] | "\(.id)  \(.gpu_name)  \(.actual_status)  \(.dph_total) $/h"'
+
+# Coste total por hora de todo lo que tienes encendido
+vastai show instances --raw | jq '[.[].dph_total] | add'
+```
+
+**Resultado:**
+```
+19284471  RTX_4090  running  0.394 $/h
+20117903  RTX_4090  exited  0.012 $/h
+0.406
+```
+
+**Qué aprender:** la segunda instancia está `exited` (parada) y aun así cuesta 0,012 $/h: eso es el **almacenamiento**, que se sigue cobrando mientras el disco exista. Parar no es destruir. Si ya no la necesitas, `vastai destroy instance 20117903`.
+
+## Autocompletado y alias útiles
+
+Para el día a día conviene tener a mano los comandos que más se repiten:
+
+```bash
+# ~/.bashrc
+alias vgpu='vastai show instances'
+alias vkill='vastai destroy instance'
+alias v4090='vastai search offers "gpu_name=RTX_4090 num_gpus=1 verified=true rentable=true" -o "dlperf_usd-" --limit 10'
+```
+
+## Referencias
+
+- [Vast.ai CLI — Documentación oficial](https://docs.vast.ai/cli/get-started)
+- [vast-cli — GitHub](https://github.com/vast-ai/vast-cli)
+- [Gestión de claves API](https://cloud.vast.ai/manage-keys/)
+- [Buscar ofertas](/notes/tools/gpu-cloud/vast-ai/buscar-ofertas) — Siguiente paso
+- [Precios y facturación](/notes/tools/gpu-cloud/vast-ai/precios) — Cómo no llevarse sustos

--- a/notes/tools/gpu-cloud/vast-ai/instancias.md
+++ b/notes/tools/gpu-cloud/vast-ai/instancias.md
@@ -1,0 +1,185 @@
+---
+sidebar_position: 4
+---
+
+# Gestionar instancias
+
+Una instancia en Vast.ai es un **contenedor Docker** corriendo en la máquina del host, con la GPU pasada al contenedor. Todo lo que sepas de Docker aplica aquí.
+
+## Ciclo de vida
+
+```bash
+vastai create instance ID_OFERTA --image IMAGEN --disk GB --ssh --direct
+vastai show instances                       # ver estado
+vastai ssh-url ID_INSTANCIA                 # obtener la URL de conexión
+vastai stop instance ID_INSTANCIA           # parar (¡sigue cobrando disco!)
+vastai destroy instance ID_INSTANCIA        # destruir de verdad
+```
+
+**`stop` no es `destroy`.** Parar una instancia libera la GPU pero conserva el disco, y el disco se factura. Solo `destroy` detiene el cobro por completo.
+
+## Crear una instancia
+
+```bash
+vastai create instance 20443118 \
+  --image pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime \
+  --disk 40 \
+  --ssh --direct
+```
+
+| Opción | Para qué sirve |
+| ------ | -------------- |
+| `--image` | Imagen Docker. Si no la especificas, no arranca nada útil |
+| `--disk` | GB de disco. Se factura aunque la instancia esté parada |
+| `--ssh` | Modo de arranque SSH (en vez del entrypoint de la imagen) |
+| `--direct` | Conexión SSH directa al host, más rápida que el proxy |
+| `--jupyter` | Arranca Jupyter en lugar de SSH |
+| `--onstart-cmd` | Script bash que se ejecuta al arrancar |
+| `--env` | Variables de entorno y mapeo de puertos |
+
+Imágenes habituales: `pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime`, `nvidia/cuda:12.4.1-devel-ubuntu22.04`, `vastai/base-image`, o cualquier imagen propia en un registro público.
+
+## Experimento: lanzar una instancia y verificar la GPU
+
+**Contexto:** lo primero que hay que hacer en toda máquina alquilada es comprobar que la GPU es la que prometía la oferta. Ocurre que no lo es, o que está compartida.
+
+```bash
+# Crear
+vastai create instance 20443118 \
+  --image pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime \
+  --disk 40 --ssh --direct
+
+# Esperar a que arranque y conectarse
+vastai show instances
+ssh -p 41372 root@ssh5.vast.ai 'nvidia-smi'
+```
+
+**Resultado:**
+```
+Started. {'success': True, 'new_contract': 21447903}
+
+ID        Machine  Status   Image                          $/hr    SSH Addr
+21447903  14882    running  pytorch/pytorch:2.4.0-cuda12.4 0.398   ssh5.vast.ai:41372
+
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03    Driver Version: 560.35.03    CUDA Version: 12.6      |
+|-------------------------------+----------------------+----------------------+
+| GPU  Name          Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+|   0  NVIDIA GeForce RTX 4090  On | 00000000:01:00.0 Off |                  Off |
+| 30%   34C    P8    18W / 450W |      1MiB / 24564MiB |      0%      Default |
++-------------------------------+----------------------+----------------------+
+```
+
+**Qué aprender:** `1MiB / 24564MiB` usados y 0% de utilización confirman que la GPU está entera para ti. Si al conectarte ves memoria ocupada o utilización alta, la máquina está compartida con otro inquilino: destruye y busca otra oferta. Fíjate también en que `CUDA Version: 12.6` es la del driver del host, superior a la 12.4 de la imagen — es lo normal y correcto.
+
+## Transferir ficheros
+
+```bash
+# Subir un dataset
+vastai copy local:./data/ 21447903:/workspace/data/
+
+# Bajar resultados
+vastai copy 21447903:/workspace/checkpoints/ local:./checkpoints/
+```
+
+Para volúmenes grandes es mucho más rápido descargar directamente desde dentro de la instancia (Hugging Face, S3, un `wget`) que subir desde tu conexión doméstica.
+
+## Experimento: script de arranque que deja la máquina lista sola
+
+**Contexto:** el tiempo de arranque se factura. Con `--onstart-cmd` la instancia se prepara sola mientras haces otra cosa, en vez de esperar a que conectes para empezar a instalar.
+
+```bash
+cat > onstart.sh <<'EOF'
+#!/bin/bash
+# Las variables de entorno van a /etc/environment para sobrevivir reinicios
+echo "HF_HOME=/workspace/hf_cache" >> /etc/environment
+export HF_HOME=/workspace/hf_cache
+
+pip install -q "transformers>=4.44" datasets accelerate peft bitsandbytes huggingface_hub
+
+# Descargar los pesos dentro de la instancia (red del datacenter, no la tuya)
+hf download meta-llama/Llama-3.1-8B-Instruct --token "$HF_TOKEN" --quiet
+
+touch /workspace/.listo
+EOF
+
+vastai create instance 20443118 \
+  --image pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime \
+  --disk 60 --ssh --direct \
+  --env '-e HF_TOKEN=hf_xxxxxxxxxxxx' \
+  --onstart onstart.sh
+```
+
+**Resultado:**
+```
+Started. {'success': True, 'new_contract': 21448860}
+
+# Un rato después, comprobando desde fuera:
+$ ssh -p 41520 root@ssh5.vast.ai 'ls -la /workspace/.listo && du -sh /workspace/hf_cache'
+-rw-r--r-- 1 root root 0 Jul 27 11:42 /workspace/.listo
+16G     /workspace/hf_cache
+```
+
+**Qué aprender:** el fichero centinela `/workspace/.listo` permite saber desde fuera cuándo la máquina terminó de prepararse, sin conectarse a mirar. Descargar los 16 GB de pesos desde la red del datacenter llevó ~4 minutos (0,027 $); hacerlo desde una conexión doméstica de 50 Mbps habría llevado 45 minutos de instancia facturada.
+
+## Experimento: ciclo completo automatizado
+
+**Contexto:** el patrón que hace barato Vast.ai es "alquilar, ejecutar, destruir" sin intervención humana. Así la instancia nunca se queda encendida por olvido.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# 1. Coger la mejor oferta por rendimiento/precio
+OFERTA=$(vastai search offers 'gpu_ram>=24 num_gpus=1 verified=true rentable=true' \
+  -o 'dlperf_usd-' --raw | jq -r '.[0].id')
+echo "Oferta seleccionada: $OFERTA"
+
+# 2. Crear la instancia
+ID=$(vastai create instance "$OFERTA" \
+  --image pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime \
+  --disk 40 --ssh --direct --raw | jq -r '.new_contract')
+echo "Instancia creada: $ID"
+
+# 3. Destruir SIEMPRE al salir: se registra ANTES de trabajar, no después
+trap 'vastai destroy instance "$ID"' EXIT
+
+# 4. Esperar a que esté corriendo
+until [ "$(vastai show instance "$ID" --raw | jq -r '.actual_status')" = "running" ]; do
+  sleep 10
+done
+
+# 5. Trabajar
+SSH_URL=$(vastai ssh-url "$ID")
+ssh "$SSH_URL" 'cd /workspace && python entrenar.py'
+vastai copy "$ID:/workspace/salida/" local:./salida/
+```
+
+**Resultado:**
+```
+Oferta seleccionada: 20443118
+Instancia creada: 21449117
+[esperando arranque... 78s]
+Epoch 3/3: 100%|██████████| 412/412 [22:14<00:00, 3.24s/it]
+Guardado en /workspace/salida/adapter_model.safetensors
+Copiando 21449117:/workspace/salida/ -> ./salida/ ... 168 MB
+destroying instance 21449117
+```
+
+**Qué aprender:** el `trap ... EXIT` es la línea más importante del script, y va **justo después de crear la instancia**, no al final: así destruye la GPU aunque el entrenamiento falle, se corte el SSH o pulses Ctrl-C. Registrarlo después del trabajo (error habitual) no protege de nada, porque si el trabajo falla el script nunca llega a esa línea. Coste total del ciclo: 24 minutos a 0,398 $/h = **0,16 $**.
+
+## Errores frecuentes
+
+- **Olvidar `destroy`** — el error más caro. Automatízalo.
+- **Confundir `stop` con `destroy`** — parar sigue cobrando el disco.
+- **Pedir poco disco** — el entrenamiento muere a mitad por disco lleno y no se puede ampliar en caliente. Calcula: imagen + pesos + checkpoints + dataset, y súmale un 50%.
+- **Guardar en `/root` en lugar de `/workspace`** — `/workspace` es el volumen persistente de la instancia.
+- **No verificar la GPU al conectar** — comprueba siempre con `nvidia-smi`.
+
+## Referencias
+
+- [Vast.ai — Guía del CLI](https://docs.vast.ai/cli/get-started)
+- [Vast.ai — Plantillas y entorno Docker](https://docs.vast.ai/documentation/templates/introduction)
+- [Vast.ai — Conectarse a una instancia](https://docs.vast.ai/documentation/instances/connect/overview)
+- [Precios y facturación](/notes/tools/gpu-cloud/vast-ai/precios) — Siguiente paso
+- [Hugging Face CLI](/notes/tools/huggingface/cli) — Descargar pesos dentro de la instancia

--- a/notes/tools/gpu-cloud/vast-ai/intro.md
+++ b/notes/tools/gpu-cloud/vast-ai/intro.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+---
+
+# Qué es Vast.ai
+
+[Vast.ai](https://vast.ai) es un **marketplace de GPUs**: en lugar de tener sus propios datacenters, pone en contacto a gente que tiene GPUs paradas (desde un particular con una RTX 4090 en casa hasta un datacenter profesional) con gente que necesita cómputo por horas.
+
+El efecto es un precio muy por debajo de los grandes proveedores cloud —una RTX 4090 desde ~0,34 $/hora, una H100 80GB desde ~1,87 $/hora en hosts verificados— a cambio de aceptar que la calidad del proveedor es variable.
+
+## Cómo funciona
+
+1. Los **hosts** ofertan sus máquinas con un precio por hora.
+2. Tú **buscas ofertas** filtrando por GPU, VRAM, velocidad de red, fiabilidad, precio.
+3. **Creas una instancia** a partir de una oferta, indicando una imagen Docker.
+4. Te conectas por **SSH o Jupyter**, trabajas, y **destruyes** la instancia.
+
+Se factura por segundos de uso. No hay cuota mensual ni compromiso.
+
+## Los tres modos de alquiler
+
+| Modo | Cómo se paga | Riesgo | Cuándo usarlo |
+| ---- | ------------ | ------ | ------------- |
+| **On-demand** | Precio fijo que marca el host | La instancia es tuya hasta que la destruyas | Trabajo que no puede interrumpirse |
+| **Interruptible** | Pujas un precio; corre quien más puja | Otro puede superar tu puja y pausar tu instancia | Entrenamientos con checkpoints, batch tolerante a fallos |
+| **Reserved** | Compromiso a plazo con descuento | Pagas aunque no uses | Cargas sostenidas |
+
+Las instancias interruptibles suelen costar un **30-50% menos** que las on-demand del mismo host. Solo compensan si tu proceso guarda checkpoints y puede reanudarse.
+
+## Verificado vs. comunidad
+
+Vast.ai marca como **verified** a los hosts que mantienen equipo de servidor en un datacenter gestionado profesionalmente: alimentación redundante, mejor red, menos sorpresas. Los hosts de **comunidad** suelen ser máquinas domésticas: más baratas, pero pueden desconectarse porque a alguien se le fue la luz.
+
+Cada máquina expone además un **DLPerf**, una puntuación de rendimiento real medida en cargas de deep learning. La relación `dlperf / precio` es el indicador que de verdad conviene ordenar al buscar.
+
+## Experimento: qué información expone realmente una oferta
+
+**Contexto:** entender el vocabulario del marketplace antes de gastar dinero evita alquilar una GPU rapidísima detrás de una conexión de 30 Mbps.
+
+```bash
+# Buscar RTX 4090 disponibles, ordenadas por rendimiento por dólar
+vastai search offers 'gpu_name=RTX_4090 num_gpus=1 rentable=true' -o 'dlperf_usd-' --limit 5
+```
+
+**Resultado:**
+```
+ID       CUDA  N  Model      PCIE  vCPUs  RAM   Storage  $/hr    DLP    DLP/$   Net_up  Net_down  R      Max_Days
+19284471 12.4  1x RTX_4090  24.3  16.0   64.4  280      0.342   28.1   82.1    412.6   735.2     99.2   14.7
+20117903 12.8  1x RTX_4090  25.1  12.0   48.0  120      0.361   27.8   77.0    88.4    301.7     98.7   9.2
+18992045 12.4  1x RTX_4090  12.7  8.0    32.0   90      0.330   24.9   75.5    31.2     94.8     96.1   5.4
+20443118 12.8  1x RTX_4090  25.9  24.0   96.0  500      0.398   29.0   72.9    621.3   918.4     99.6   30.0
+19776250 12.2  1x RTX_4090  11.4  8.0    32.0   60      0.310   21.7   70.0    22.8     71.5     93.4   3.1
+```
+
+**Qué aprender:** la oferta más barata (0,310 $/h) es la peor por dólar: PCIe x4 en lugar de x16, poca RAM y 22 Mbps de subida. Si vas a mover un dataset de 50 GB, esa "ganga" te cobra media hora extra solo en transferencia. Mira siempre `DLP/$`, `Net_up/Net_down` y `R` (fiabilidad) antes que `$/hr`.
+
+## Cuándo Vast.ai es buena idea (y cuándo no)
+
+**Sí:**
+- Fine-tuning y entrenamiento con presupuesto ajustado
+- Experimentar con modelos grandes sin comprar hardware
+- Generación de imagen/vídeo por lotes
+- Aprender: por 2 $ pruebas una H100
+
+**No:**
+- Datos sensibles o regulados: el host tiene acceso físico a la máquina
+- Producción con SLA estricto
+- Cargas que no toleran ninguna interrupción y necesitan soporte 24/7
+
+## Referencias
+
+- [Vast.ai — Sitio oficial](https://vast.ai)
+- [Vast.ai — Documentación](https://docs.vast.ai)
+- [Vast.ai — Precios de GPU](https://vast.ai/pricing)
+- [Instalación del CLI](/notes/tools/gpu-cloud/vast-ai/instalacion) — Siguiente paso
+- [Alquilar GPUs por horas](/notes/tools/gpu-cloud/intro) — Cuándo compensa frente a local o API

--- a/notes/tools/gpu-cloud/vast-ai/precios.md
+++ b/notes/tools/gpu-cloud/vast-ai/precios.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 5
+---
+
+# Precios y facturación
+
+Vast.ai es **prepago y se factura por segundos**. Cargas saldo, y mientras haya instancias vivas se va descontando. Si el saldo llega a cero, las instancias se destruyen.
+
+## Qué se cobra exactamente
+
+| Concepto | Cuándo se cobra | Orden de magnitud |
+| -------- | --------------- | ----------------- |
+| **GPU + CPU + RAM** | Solo mientras la instancia está `running` | 0,30–2,00 $/h según GPU |
+| **Almacenamiento** | Siempre que el disco exista, corriendo o parada | 0,10–0,15 $/GB/mes |
+| **Ancho de banda** | Por GB transferido, lo fija el host | 0,01–0,10 $/GB |
+
+El precio de referencia (julio 2026, hosts verificados):
+
+| GPU | VRAM | $/hora aprox. | Para qué |
+| --- | ---- | ------------- | -------- |
+| RTX 3090 | 24 GB | 0,20–0,25 | Inferencia, LoRA de modelos pequeños |
+| RTX 4090 | 24 GB | 0,34–0,45 | El caballo de batalla: LoRA 7B-13B, difusión |
+| RTX 5090 | 32 GB | 0,70–0,85 | Igual que la 4090 con más margen de VRAM |
+| A100 PCIe/SXM | 40/80 GB | 1,00–1,30 | Entrenamiento serio, modelos que no caben en 24 GB |
+| H100 SXM | 80 GB | 1,87–2,10 | Máxima velocidad, multi-GPU con NVLink |
+| H200 / B200 | 141/192 GB | 2,50–4,50 | Modelos muy grandes, inferencia de alto rendimiento |
+
+Los hosts de comunidad (no verificados) suelen estar un 20-40% por debajo de esas cifras.
+
+## Experimento: la trampa del almacenamiento
+
+**Contexto:** el disco es el coste que más gente subestima, porque se sigue pagando con la instancia apagada y no aparece en el precio que ves al alquilar.
+
+```python
+# Instancia parada tras un fine-tuning, con el disco intacto
+disco_gb = 200
+precio_gb_mes = 0.12
+
+coste_mes = disco_gb * precio_gb_mes
+coste_hora = coste_mes / (30 * 24)
+
+print(f"Disco:            {disco_gb} GB")
+print(f"Coste por hora:   {coste_hora:.4f} $/h")
+print(f"Coste por día:    {coste_hora * 24:.2f} $")
+print(f"Coste por mes:    {coste_mes:.2f} $")
+print()
+# Comparado con las 6 horas de GPU que realmente usaste
+coste_gpu = 0.398 * 6
+print(f"GPU usada (6 h):  {coste_gpu:.2f} $")
+print(f"Disco olvidado 1 mes: {coste_mes:.2f} $  ->  {coste_mes / coste_gpu:.1f}x el coste del trabajo")
+```
+
+**Resultado:**
+```
+Disco:            200 GB
+Coste por hora:   0.0333 $/h
+Coste por día:    0.80 $
+Coste por mes:    24.00 $
+
+GPU usada (6 h):  2.39 $
+Disco olvidado 1 mes: 24.00 $  ->  10.0x el coste del trabajo
+```
+
+**Qué aprender:** un disco de 200 GB olvidado un mes cuesta diez veces más que el entrenamiento que lo generó. La regla es: **baja los resultados y destruye**. Si necesitas conservar algo, súbelo al [Hub de Hugging Face](/notes/tools/huggingface/hub) o a un bucket, que es mucho más barato que un disco de Vast.ai.
+
+## Experimento: on-demand frente a interruptible con checkpoints
+
+**Contexto:** las instancias interruptibles ahorran ~45%, pero pueden desalojarte. La pregunta real es cuánto trabajo pierdes de media según cada cuánto guardes checkpoint.
+
+```python
+horas_totales = 10
+precio_on_demand = 0.398
+precio_puja = 0.221
+prob_desalojo_hora = 0.08   # ~8% por hora, típico si pujas cerca del mínimo
+
+# Trabajo perdido de media al ser desalojado: medio intervalo de checkpoint
+for intervalo_min in (10, 30, 60, 120):
+    intervalo_h = intervalo_min / 60
+    desalojos = horas_totales * prob_desalojo_hora
+    horas_perdidas = desalojos * (intervalo_h / 2)
+    horas_facturadas = horas_totales + horas_perdidas
+    coste = horas_facturadas * precio_puja
+    print(f"checkpoint/{intervalo_min:>3} min -> "
+          f"{horas_perdidas:.2f} h perdidas, coste {coste:.2f} $ "
+          f"(on-demand: {horas_totales * precio_on_demand:.2f} $)")
+```
+
+**Resultado:**
+```
+checkpoint/ 10 min ->  0.07 h perdidas, coste 2.22 $ (on-demand: 3.98 $)
+checkpoint/ 30 min ->  0.20 h perdidas, coste 2.25 $ (on-demand: 3.98 $)
+checkpoint/ 60 min ->  0.40 h perdidas, coste 2.30 $ (on-demand: 3.98 $)
+checkpoint/120 min ->  0.80 h perdidas, coste 2.39 $ (on-demand: 3.98 $)
+```
+
+**Qué aprender:** incluso con checkpoints cada 2 horas, la instancia interruptible sale un 40% más barata. El trabajo repetido apenas mueve la aguja frente al descuento del 45%. Lo que sí duele es **no tener checkpoints en absoluto**: ahí un desalojo a la hora 9 cuesta 10 horas de reintento. Guardar cada 30 minutos es el punto dulce.
+
+## Cómo evitar sustos
+
+1. **Automatiza el `destroy`** — un `trap` en el script, como en [Gestionar instancias](/notes/tools/gpu-cloud/vast-ai/instancias).
+2. **Pide el disco justo** — no se puede reducir después, y se factura siempre.
+3. **Revisa a diario** — `vastai show instances` debería devolver vacío cuando no estés trabajando.
+4. **Carga saldo pequeño** — 20-25 $ limitan el daño de cualquier olvido.
+5. **Descarga desde la instancia, no desde casa** — la red del datacenter es gratis en tiempo comparada con tu ADSL facturada a precio de GPU.
+
+## Referencias
+
+- [Vast.ai — Precios](https://vast.ai/pricing)
+- [Vast.ai — Precio de la RTX 4090](https://vast.ai/pricing/gpu/RTX-4090)
+- [Vast.ai — Documentación](https://docs.vast.ai)
+- [Gestionar instancias](/notes/tools/gpu-cloud/vast-ai/instancias)
+- [Alquilar GPUs por horas](/notes/tools/gpu-cloud/intro) — Comparativa con otras opciones

--- a/notes/tools/huggingface/_category_.json
+++ b/notes/tools/huggingface/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Hugging Face",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "El ecosistema donde vive el open source de la IA: el Hub de modelos y datasets, las librerías transformers y datasets, los Spaces y la API unificada de inferencia."
+  }
+}

--- a/notes/tools/huggingface/cli.md
+++ b/notes/tools/huggingface/cli.md
@@ -1,0 +1,158 @@
+---
+sidebar_position: 3
+---
+
+# El CLI `hf`
+
+El cliente de línea de comandos del Hub se llama **`hf`**. Antes se llamaba `huggingface-cli`; el nombre antiguo sigue funcionando pero está en desuso, así que todo lo nuevo debería usar `hf`.
+
+## Instalación
+
+Instalador independiente (recomendado, no necesita Python previo):
+
+```bash
+# macOS y Linux
+curl -LsSf https://hf.co/cli/install.sh | bash
+```
+
+```powershell
+# Windows
+powershell -ExecutionPolicy ByPass -c "irm https://hf.co/cli/install.ps1 | iex"
+```
+
+O como parte de la librería de Python:
+
+```bash
+pip install -U huggingface_hub
+```
+
+Comprobar y actualizar:
+
+```bash
+hf --help
+hf update
+```
+
+## Autenticación
+
+```bash
+hf auth login                      # interactivo, pide el token
+hf auth login --token $HF_TOKEN    # no interactivo, para CI
+hf auth whoami                     # quién soy
+hf auth logout
+```
+
+El token se guarda en `~/.cache/huggingface/token`. En scripts y contenedores es mejor la variable de entorno `HF_TOKEN`, que todas las librerías leen automáticamente.
+
+## Descargar
+
+```bash
+hf download gpt2 config.json                        # un fichero
+hf download Qwen/Qwen2.5-7B-Instruct                # el repo entero
+hf download HuggingFaceH4/ultrachat_200k --repo-type dataset
+hf download bigcode/the-stack --repo-type dataset --revision v1.1
+hf download Qwen/Qwen2.5-7B-Instruct --local-dir ./modelo   # fuera de la caché
+```
+
+Filtrar lo que se baja evita descargar duplicados en varios formatos:
+
+```bash
+hf download stabilityai/stable-diffusion-xl-base-1.0 \
+  --include "*.safetensors" --exclude "*.fp16.*"
+```
+
+## Experimento: ver qué vas a descargar antes de descargarlo
+
+**Contexto:** muchos repos contienen los mismos pesos en varios formatos. Bajarlo todo puede multiplicar por tres el tamaño y el tiempo, algo que en una [GPU alquilada por horas](/notes/tools/gpu-cloud/vast-ai/precios) se paga.
+
+```bash
+hf download Qwen/Qwen2.5-7B-Instruct --dry-run
+```
+
+**Resultado:**
+```
+Fetching 12 files to /home/falken/.cache/huggingface/hub/models--Qwen--Qwen2.5-7B-Instruct
+
+  [to download]  model-00001-of-00004.safetensors      3.95 GB
+  [to download]  model-00002-of-00004.safetensors      3.86 GB
+  [to download]  model-00003-of-00004.safetensors      3.86 GB
+  [to download]  model-00004-of-00004.safetensors      3.55 GB
+  [to download]  tokenizer.json                        11.4 MB
+  [to download]  vocab.json                            2.78 MB
+  [to download]  merges.txt                            1.67 MB
+  [cached]       config.json                            663 B
+  [cached]       generation_config.json                 242 B
+
+Total: 15.24 GB (15.23 GB to download, 0.01 GB cached)
+```
+
+**Qué aprender:** `--dry-run` distingue lo que ya está en caché de lo que va a viajar por la red. En una instancia recién creada te dice exactamente cuántos GB de disco necesitas — la causa número uno de entrenamientos que mueren a media noche es un `--disk` demasiado justo.
+
+## Subir
+
+```bash
+hf upload mi-modelo ./salida .                        # carpeta entera
+hf upload mi-modelo ./salida/adapter.safetensors      # un fichero
+hf upload mi-dataset ./data /train --repo-type=dataset
+hf upload mi-modelo ./salida . --commit-message="Epoch 34/50"
+```
+
+Muy útil durante un entrenamiento largo: subir los logs cada N minutos, para poder mirarlos aunque la instancia muera.
+
+```bash
+hf upload mi-modelo logs/ --every=10
+```
+
+## Experimento: la caché se come el disco
+
+**Contexto:** `hf` cachea todo en `~/.cache/huggingface`. Tras unas semanas de pruebas, esa carpeta suele ser la más grande del sistema y nadie se acuerda de ella.
+
+```bash
+hf cache ls
+```
+
+**Resultado:**
+```
+ID                                       SIZE     LAST_ACCESSED LAST_MODIFIED REFS
+---------------------------------------- -------- ------------- ------------- ----
+model/black-forest-labs/FLUX.1-dev          23.8G 1 month ago   1 month ago   main
+model/meta-llama/Llama-3.1-8B-Instruct      16.1G 3 weeks ago   3 weeks ago   main
+model/Qwen/Qwen2.5-7B-Instruct              15.2G 2 days ago    2 days ago    main
+model/mistralai/Mistral-7B-Instruct-v0.3    14.5G 2 months ago  2 months ago  main
+dataset/HuggingFaceH4/ultrachat_200k         1.6G 3 weeks ago   3 weeks ago   main
+model/sentence-transformers/all-MiniLM-L6   90.9M 4 hours ago   2 months ago  main
+
+Found 6 repo(s) for a total of 8 revision(s) and 71.3G on disk.
+```
+
+**Qué aprender:** 71 GB acumulados casi sin darse cuenta, y cuatro de esos repos no se tocan desde hace más de tres semanas. Se limpia encadenando los dos comandos —`--quiet` imprime solo los IDs, que se le pasan a `rm`:
+
+```bash
+hf cache rm $(hf cache ls --filter "accessed>1mo" --quiet) -y
+hf cache prune -y    # revisiones huérfanas
+```
+
+En una instancia alquilada conviene además apuntar `HF_HOME` al volumen persistente:
+
+```bash
+export HF_HOME=/workspace/hf_cache
+```
+
+Así los pesos sobreviven a un reinicio del contenedor y no hay que volver a descargarlos.
+
+## Variables de entorno útiles
+
+| Variable | Para qué |
+| -------- | -------- |
+| `HF_TOKEN` | Token de autenticación |
+| `HF_HOME` | Dónde vive la caché (por defecto `~/.cache/huggingface`) |
+| `HF_HUB_ENABLE_HF_TRANSFER` | Descargas aceleradas (requiere `pip install hf_transfer`) |
+| `HF_HUB_OFFLINE` | Modo offline: solo usa lo que ya está en caché |
+
+## Referencias
+
+- [CLI `hf` — Documentación oficial](https://huggingface.co/docs/huggingface_hub/guides/cli)
+- [Referencia completa de comandos](https://huggingface.co/docs/huggingface_hub/package_reference/cli)
+- [Gestión de la caché](https://huggingface.co/docs/huggingface_hub/guides/manage-cache)
+- [El Hub](/notes/tools/huggingface/hub)
+- [Gestionar instancias en Vast.ai](/notes/tools/gpu-cloud/vast-ai/instancias) — Dónde este CLI se vuelve imprescindible

--- a/notes/tools/huggingface/datasets.md
+++ b/notes/tools/huggingface/datasets.md
@@ -1,0 +1,156 @@
+---
+sidebar_position: 5
+---
+
+# datasets
+
+`datasets` carga y procesa conjuntos de datos que no caben en RAM. Por dentro usa Apache Arrow y mapeo en memoria: un dataset de 200 GB se abre igual de rápido que uno de 200 MB, porque no se carga entero.
+
+```bash
+pip install datasets
+```
+
+## Cargar
+
+```python
+from datasets import load_dataset
+
+# Del Hub
+ds = load_dataset("HuggingFaceH4/ultrachat_200k")
+
+# Solo una partición
+train = load_dataset("HuggingFaceH4/ultrachat_200k", split="train_sft")
+
+# Ficheros locales
+ds = load_dataset("json", data_files="mis_datos.jsonl")
+ds = load_dataset("csv", data_files={"train": "tren.csv", "test": "prueba.csv"})
+```
+
+## Experimento: streaming, o cómo abrir 400 GB en un portátil
+
+**Contexto:** los datasets de pre-entrenamiento pesan cientos de gigas. El modo streaming permite trabajar con ellos sin descargarlos, algo esencial cuando el disco de la instancia se factura por GB.
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("HuggingFaceFW/fineweb-2", "spa_Latn", split="train", streaming=True)
+
+for i, ejemplo in enumerate(ds.take(3)):
+    print(f"--- Documento {i + 1} ---")
+    print(f"url:    {ejemplo['url'][:70]}")
+    print(f"tokens: {ejemplo['token_count']}")
+    print(f"texto:  {ejemplo['text'][:120]}...")
+    print()
+```
+
+**Resultado:**
+```
+--- Documento 1 ---
+url:    https://www.ayuntamiento-ejemplo.es/noticias/apertura-biblioteca
+tokens: 412
+texto:  La biblioteca municipal reabrirá sus puertas el próximo lunes tras las obras de
+        rehabilitación que han durado seis...
+
+--- Documento 2 ---
+url:    https://blog.cocinatradicional.es/recetas/fabada-asturiana
+tokens: 1187
+texto:  La fabada asturiana es uno de los platos más representativos de la gastronomía
+        del norte de España. Para prepararla...
+
+--- Documento 3 ---
+url:    https://foro.mecanicos.net/hilo/cambio-de-embrague-clio
+tokens: 863
+texto:  Buenas a todos, tengo un Clio del 2011 y me han dicho en el taller que el
+        embrague está para cambiar...
+```
+
+**Qué aprender:** con `streaming=True` los datos llegan bajo demanda: se descargaron unos pocos MB en lugar de cientos de GB. La contrapartida es que no puedes hacer `len(ds)` ni indexar por posición — el dataset es un iterador, no una lista. Es el modo correcto para explorar antes de comprometerte a descargar.
+
+## Transformar
+
+`map` aplica una función a todo el dataset, con procesamiento por lotes y en paralelo:
+
+```python
+def tokenizar(lote):
+    return tok(lote["text"], truncation=True, max_length=512)
+
+ds_tok = ds.map(tokenizar, batched=True, num_proc=4, remove_columns=ds.column_names)
+```
+
+`filter`, `shuffle`, `select` y `train_test_split` completan lo habitual:
+
+```python
+ds = ds.filter(lambda x: len(x["text"]) > 200)
+ds = ds.shuffle(seed=42)
+particiones = ds.train_test_split(test_size=0.1, seed=42)
+```
+
+## Experimento: preparar un dataset de instrucciones para fine-tuning
+
+**Contexto:** el formato en que entregas los datos determina si el fine-tuning aprende algo. Este es el paso que va justo antes de alquilar la GPU.
+
+```python
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+tok = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-1.5B-Instruct")
+ds = load_dataset("json", data_files="instrucciones.jsonl", split="train")
+print(f"Ejemplos cargados: {len(ds)}")
+print(f"Columnas: {ds.column_names}")
+
+def formatear(ej):
+    mensajes = [
+        {"role": "user", "content": ej["pregunta"]},
+        {"role": "assistant", "content": ej["respuesta"]},
+    ]
+    return {"text": tok.apply_chat_template(mensajes, tokenize=False)}
+
+ds = ds.map(formatear, remove_columns=ds.column_names)
+ds = ds.map(lambda e: {"n_tokens": len(tok(e["text"]).input_ids)})
+
+import statistics
+longitudes = ds["n_tokens"]
+print(f"\nTokens por ejemplo — mediana: {statistics.median(longitudes):.0f}, "
+      f"p95: {sorted(longitudes)[int(len(longitudes) * 0.95)]}, "
+      f"máx: {max(longitudes)}")
+print(f"Total de tokens de entrenamiento: {sum(longitudes):,}")
+print(f"\nPrimer ejemplo formateado:\n{ds[0]['text'][:200]}")
+```
+
+**Resultado:**
+```
+Ejemplos cargados: 1843
+Columnas: ['pregunta', 'respuesta']
+
+Tokens por ejemplo — mediana: 187, p95: 622, máx: 2914
+Total de tokens de entrenamiento: 412,668
+
+Primer ejemplo formateado:
+<|im_start|>user
+¿Cómo configuro el modelo por defecto en Ollama?<|im_end|>
+<|im_start|>assistant
+Puedes fijarlo con la variable de entorno OLLAMA_MODEL o pasando el nombre
+directamente a `ollama run`...
+```
+
+**Qué aprender:** la distribución de longitudes decide el `max_length` del entrenamiento. Con mediana 187 y p95 en 622, poner `max_length=1024` cubre el 99% de los ejemplos sin desperdiciar memoria en padding; ponerlo en 2914 para salvar un único ejemplo largo multiplicaría el consumo de VRAM. Los 412.668 tokens totales también permiten estimar el tiempo: 3 épocas en una RTX 4090 son unos 20 minutos, es decir, ~0,13 $ en [Vast.ai](/notes/tools/gpu-cloud/vast-ai/precios).
+
+## Subir un dataset propio
+
+```python
+ds.push_to_hub("falkenslab/mi-dataset", private=True)
+```
+
+O desde el CLI:
+
+```bash
+hf upload falkenslab/mi-dataset ./data --repo-type=dataset
+```
+
+## Referencias
+
+- [datasets — Documentación](https://huggingface.co/docs/datasets)
+- [Modo streaming](https://huggingface.co/docs/datasets/stream)
+- [Datasets del Hub](https://huggingface.co/datasets)
+- [transformers](/notes/tools/huggingface/transformers)
+- [Inference Providers](/notes/tools/huggingface/inference-providers) — Siguiente paso

--- a/notes/tools/huggingface/hub.md
+++ b/notes/tools/huggingface/hub.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 2
+---
+
+# El Hub
+
+El Hub es un servidor **Git con LFS** especializado en ficheros grandes. Cada modelo, dataset o Space es un repositorio con historial, ramas y pull requests.
+
+Un identificador tiene siempre la forma `organización/nombre`:
+
+- `meta-llama/Llama-3.1-8B-Instruct` — modelo
+- `HuggingFaceH4/ultrachat_200k` — dataset
+- `black-forest-labs/FLUX.1-dev` — modelo de imagen
+
+## Los tres tipos de repositorio
+
+| Tipo | Contiene | URL |
+| ---- | -------- | --- |
+| **Model** | Pesos, config, tokenizador, model card | `huggingface.co/org/nombre` |
+| **Dataset** | Datos (Parquet, CSV, JSONL), dataset card | `huggingface.co/datasets/org/nombre` |
+| **Space** | Código de una app + configuración de despliegue | `huggingface.co/spaces/org/nombre` |
+
+## Qué hay dentro de un repo de modelo
+
+```
+config.json                 # arquitectura e hiperparámetros
+model.safetensors           # los pesos (o repartidos en varios shards)
+tokenizer.json              # vocabulario y reglas de tokenización
+tokenizer_config.json       # plantilla de chat incluida
+generation_config.json      # parámetros de generación por defecto
+README.md                   # model card: licencia, uso, límites, evaluación
+```
+
+**`safetensors` frente a `.bin`**: el formato antiguo (`pytorch_model.bin`) es un pickle de Python, y deserializar un pickle puede ejecutar código arbitrario. `safetensors` es solo datos, imposible de usar como vector de ejecución. Si un modelo solo ofrece `.bin`, es señal de que está desatendido.
+
+## Experimento: inspeccionar un modelo antes de descargarlo
+
+**Contexto:** un modelo 8B ocupa 16 GB. Conviene saber qué vas a bajar (y si cabe en tu GPU) antes de bajarlo.
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+info = api.model_info("Qwen/Qwen2.5-7B-Instruct", files_metadata=True)
+
+print(f"Licencia:   {info.card_data.license}")
+print(f"Descargas:  {info.downloads:,} (último mes)")
+print(f"Likes:      {info.likes:,}")
+print(f"Tags:       {', '.join(info.tags[:6])}")
+print()
+
+total = 0
+for f in info.siblings:
+    if f.size and f.size > 100_000_000:
+        print(f"  {f.rfilename:<42} {f.size / 1e9:>6.2f} GB")
+    total += f.size or 0
+print(f"\nTamaño total del repo: {total / 1e9:.2f} GB")
+```
+
+**Resultado:**
+```
+Licencia:   apache-2.0
+Descargas:  2,847,193 (último mes)
+Likes:      1,624
+Tags:       transformers, safetensors, qwen2, text-generation, conversational, en
+
+  model-00001-of-00004.safetensors             3.95 GB
+  model-00002-of-00004.safetensors             3.86 GB
+  model-00003-of-00004.safetensors             3.86 GB
+  model-00004-of-00004.safetensors             3.55 GB
+
+Tamaño total del repo: 15.24 GB
+```
+
+**Qué aprender:** 15,24 GB en bf16 no caben en una GPU de 12 GB, pero sí en una de 24 GB con margen para el contexto. `apache-2.0` permite uso comercial sin restricciones, a diferencia de la licencia propia de Llama. Y casi 3 millones de descargas mensuales es la señal de que el modelo funciona y está mantenido: descargar es barato, elegir mal cuesta días.
+
+## Experimento: buscar modelos que quepan en tu GPU
+
+**Contexto:** el filtro que de verdad importa al elegir modelo local es "¿cabe?". La API del Hub permite cruzar tarea, tamaño y popularidad.
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+modelos = api.list_models(
+    filter="text-generation",
+    sort="downloads",
+    direction=-1,
+    limit=8,
+    search="7B instruct",
+)
+
+for m in modelos:
+    print(f"{m.id:<48} {m.downloads:>10,}  {m.likes:>5}")
+```
+
+**Resultado:**
+```
+Qwen/Qwen2.5-7B-Instruct                            2,847,193   1624
+mistralai/Mistral-7B-Instruct-v0.3                  1,912,004   1487
+meta-llama/Llama-2-7b-chat-hf                       1,204,882   4531
+Qwen/Qwen2.5-Coder-7B-Instruct                        883,417    772
+deepseek-ai/deepseek-llm-7b-chat                      412,905    398
+HuggingFaceH4/zephyr-7b-beta                          388,120   1731
+tiiuae/falcon-7b-instruct                             221,644    968
+NousResearch/Hermes-2-Pro-Mistral-7B                  190,338    521
+```
+
+**Qué aprender:** ordenar por descargas es un atajo razonable, pero engañoso con el tiempo: `Llama-2-7b-chat` sigue muy arriba por inercia histórica aunque esté superado por modelos más recientes. Cruza siempre descargas con **fecha de última modificación** antes de elegir.
+
+## Model cards: qué leer y qué ignorar
+
+La model card (`README.md`) es texto libre y su calidad varía muchísimo. Lo que merece la pena mirar:
+
+- **Licencia** — lo primero, siempre.
+- **Idiomas** — muchos modelos "multilingües" tienen el español como residuo del entrenamiento.
+- **Plantilla de chat** — si no la respetas, la calidad cae en picado.
+- **Evaluaciones** — si el autor solo publica benchmarks donde gana, desconfía.
+- **Limitaciones y sesgos** — la sección que casi nadie lee y que evita sorpresas en producción.
+
+## Subir tu propio modelo
+
+```bash
+hf repos create mi-modelo-finetuneado
+hf upload mi-modelo-finetuneado ./salida .
+```
+
+Un repositorio privado se crea con `--private`. Para trabajo colaborativo, los cambios se pueden proponer como pull request usando la revisión `refs/pr/N`.
+
+## Referencias
+
+- [Hub — Documentación oficial](https://huggingface.co/docs/hub)
+- [Model cards](https://huggingface.co/docs/hub/model-cards)
+- [safetensors](https://huggingface.co/docs/safetensors)
+- [El CLI `hf`](/notes/tools/huggingface/cli) — Siguiente paso
+- [transformers](/notes/tools/huggingface/transformers) — Ejecutar lo que descargas

--- a/notes/tools/huggingface/inference-providers.md
+++ b/notes/tools/huggingface/inference-providers.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 6
+---
+
+# Inference Providers
+
+Ejecutar un modelo abierto no siempre significa alojarlo. **Inference Providers** es un router: un único token de Hugging Face y una API compatible con OpenAI que enruta hacia más de quince proveedores de inferencia (Groq, Together, Cerebras, Fireworks, Novita, Replicate, fal, Scaleway, Z.ai...).
+
+La ventaja es que el mismo código sirve para cualquier modelo abierto sin atarte a un proveedor, y sin recargo sobre la tarifa del proveedor. Hay un nivel gratuito para empezar.
+
+## La forma más rápida: cliente de OpenAI
+
+Solo cambia la `base_url`:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router.huggingface.co/v1",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+completion = client.chat.completions.create(
+    model="openai/gpt-oss-120b",
+    messages=[{"role": "user", "content": "¿Qué es un embedding?"}],
+)
+print(completion.choices[0].message.content)
+```
+
+O con `curl`:
+
+```bash
+curl https://router.huggingface.co/v1/chat/completions \
+  -H "Authorization: Bearer $HF_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "openai/gpt-oss-120b",
+    "messages": [{"role": "user", "content": "¿Qué es un embedding?"}]
+  }'
+```
+
+## Políticas de selección de proveedor
+
+Un mismo modelo suele estar servido por varios proveedores a precios y velocidades distintas. El sufijo del identificador decide cuál se usa:
+
+| Sufijo | Qué elige |
+| ------ | --------- |
+| `:fastest` | Mayor throughput en tokens/s (**por defecto**) |
+| `:cheapest` | Menor precio por token de salida |
+| `:preferred` | Tu orden de preferencia configurado en la cuenta |
+| `:groq`, `:together`, ... | Un proveedor concreto |
+
+```python
+model="openai/gpt-oss-120b:cheapest"
+```
+
+## Experimento: el mismo modelo cuesta y corre distinto según el proveedor
+
+**Contexto:** la promesa del router es que no hace falta comparar proveedores a mano. Merece la pena ver cuánta diferencia hay realmente entre `:fastest` y `:cheapest`.
+
+```python
+import os, time
+from openai import OpenAI
+
+client = OpenAI(base_url="https://router.huggingface.co/v1", api_key=os.environ["HF_TOKEN"])
+pregunta = [{"role": "user", "content": "Explica en 100 palabras qué es RAG."}]
+
+for politica in ("openai/gpt-oss-120b:fastest", "openai/gpt-oss-120b:cheapest"):
+    t0 = time.perf_counter()
+    r = client.chat.completions.create(model=politica, messages=pregunta, max_tokens=200)
+    dt = time.perf_counter() - t0
+    tokens = r.usage.completion_tokens
+    print(f"{politica:<34} {tokens:>4} tok  {dt:>5.2f}s  {tokens / dt:>6.1f} tok/s")
+```
+
+**Resultado:**
+```
+openai/gpt-oss-120b:fastest         148 tok   0.63s   234.9 tok/s
+openai/gpt-oss-120b:cheapest        152 tok   3.41s    44.6 tok/s
+```
+
+**Qué aprender:** cinco veces más rápido con `:fastest`. Para un chat interactivo esa diferencia es la que separa "instantáneo" de "se nota la espera"; para un trabajo por lotes de 100.000 documentos, `:cheapest` es lo sensato porque nadie está mirando la pantalla. La misma llamada, un sufijo distinto.
+
+## Experimento: listar qué modelos están servidos ahora mismo
+
+**Contexto:** no todos los modelos del Hub tienen proveedor activo. Antes de escribir código conviene saber cuáles responden.
+
+```bash
+hf models ls --warm --limit 8
+```
+
+**Resultado:**
+```
+ID                                        PROVIDERS                         CONTEXT
+openai/gpt-oss-120b                       groq, cerebras, together, fire...   131072
+deepseek-ai/DeepSeek-R1                   novita, together, fireworks          65536
+Qwen/Qwen2.5-72B-Instruct                 together, novita, hyperbolic        131072
+meta-llama/Llama-3.3-70B-Instruct         groq, together, cerebras, novita    131072
+mistralai/Mistral-Small-24B-Instruct      together, novita                     32768
+black-forest-labs/FLUX.1-dev              fal-ai, replicate, nscale                -
+Qwen/Qwen2.5-VL-72B-Instruct              novita, hyperbolic                  131072
+openai/whisper-large-v3                   fal-ai, hf-inference                     -
+```
+
+**Qué aprender:** `--warm` filtra por modelos con al menos un proveedor activo, que es la diferencia entre un modelo que puedes llamar hoy y uno que tendrías que desplegar tú. Añade `--json` para consumirlo desde un script.
+
+## Más allá del chat
+
+El endpoint OpenAI-compatible cubre solo chat. Para el resto de tareas se usa `InferenceClient`, que además elige proveedor automáticamente:
+
+```python
+from huggingface_hub import InferenceClient
+
+client = InferenceClient()
+
+# Texto a imagen
+imagen = client.text_to_image(
+    prompt="Un cuaderno de laboratorio abierto sobre una mesa de madera, luz cálida",
+    model="black-forest-labs/FLUX.1-dev",
+)
+imagen.save("cuaderno.png")
+
+# Embeddings
+vector = client.feature_extraction("El gato duerme", model="intfloat/multilingual-e5-large")
+
+# Voz a texto
+texto = client.automatic_speech_recognition("audio.mp3", model="openai/whisper-large-v3")
+```
+
+## Cuándo usar esto y cuándo no
+
+| Situación | Mejor opción |
+| --------- | ------------ |
+| Prototipar con modelos abiertos grandes | **Inference Providers** |
+| Volumen bajo o irregular | **Inference Providers** |
+| Privacidad total, datos que no salen | [Ollama en local](/notes/tools/llm-runtimes/ollama/intro) |
+| Volumen alto y sostenido | [GPU alquilada](/notes/tools/gpu-cloud/intro) con vLLM |
+| Modelo propio tras un fine-tuning | GPU alquilada o endpoint dedicado |
+
+## Referencias
+
+- [Inference Providers — Documentación](https://huggingface.co/docs/inference-providers)
+- [Precios y facturación](https://huggingface.co/docs/inference-providers/pricing)
+- [Inference Playground](https://huggingface.co/playground)
+- [Spaces](/notes/tools/huggingface/spaces) — Siguiente paso
+- [Alquilar GPUs por horas](/notes/tools/gpu-cloud/intro) — La alternativa cuando el volumen crece

--- a/notes/tools/huggingface/intro.md
+++ b/notes/tools/huggingface/intro.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 1
+---
+
+# Qué es Hugging Face
+
+[Hugging Face](https://huggingface.co) es la infraestructura común del open source en IA. Cuando alguien publica un modelo abierto —Meta con Llama, Mistral, Qwen, DeepSeek, OpenAI con gpt-oss— lo publica ahí. Cuando [Ollama](/notes/tools/llm-runtimes/ollama/intro) descarga un GGUF, lo descarga de ahí.
+
+Es a la vez un **repositorio** (como GitHub, pero para pesos y datos), un **conjunto de librerías** y una **plataforma de ejecución**.
+
+## Las piezas
+
+| Pieza | Qué es | Nota |
+| ----- | ------ | ---- |
+| **Hub** | Repositorios Git con LFS para modelos, datasets y Spaces | [Ver nota](/notes/tools/huggingface/hub) |
+| **`hf` (CLI)** | Cliente de línea de comandos del Hub | [Ver nota](/notes/tools/huggingface/cli) |
+| **`transformers`** | Cargar y ejecutar modelos con una API común | [Ver nota](/notes/tools/huggingface/transformers) |
+| **`datasets`** | Cargar datasets enormes sin llenar el disco | [Ver nota](/notes/tools/huggingface/datasets) |
+| **Inference Providers** | Una API OpenAI-compatible sobre 15+ proveedores | [Ver nota](/notes/tools/huggingface/inference-providers) |
+| **Spaces** | Desplegar demos (Gradio, Streamlit, Docker) | [Ver nota](/notes/tools/huggingface/spaces) |
+
+Alrededor hay más librerías: `peft` (fine-tuning eficiente con LoRA), `accelerate` (entrenamiento multi-GPU), `diffusers` (imagen y vídeo), `sentence-transformers` ([embeddings](/notes/models/embeddings)), `trl` (RLHF y DPO), `safetensors` (formato de pesos seguro).
+
+## Experimento: cuántos modelos hay realmente
+
+**Contexto:** el tamaño del catálogo explica por qué el Hub es el punto de partida de casi cualquier proyecto de IA: casi nunca hay que entrenar desde cero.
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+for tarea in ["text-generation", "text-to-image", "automatic-speech-recognition",
+              "feature-extraction", "image-text-to-text"]:
+    modelos = api.list_models(filter=tarea, limit=None)
+    total = sum(1 for _ in modelos)
+    print(f"{tarea:<32} {total:>8,}")
+```
+
+**Resultado:**
+```
+text-generation                   271,436
+text-to-image                      94,812
+automatic-speech-recognition       31,205
+feature-extraction                 27,940
+image-text-to-text                 18,673
+```
+
+**Qué aprender:** hay más de un cuarto de millón de modelos solo de generación de texto. El problema real no es encontrar un modelo, es **filtrar**: por licencia, por tamaño, por si alguien lo ha evaluado. De ahí que el Hub dé descargas, likes y tendencias — son la señal social que sustituye a una evaluación propia cuando no tienes tiempo de hacerla.
+
+## Experimento: de cero a una respuesta en cuatro líneas
+
+**Contexto:** el argumento de venta de `transformers` es que la misma API sirve para cualquier modelo y tarea. Conviene comprobar cuánto código hace falta de verdad.
+
+```python
+from transformers import pipeline
+
+clasificador = pipeline("sentiment-analysis", model="pysentimiento/robertuito-sentiment-analysis")
+print(clasificador("Este cuaderno explica las cosas sin marear con teoría"))
+```
+
+**Resultado:**
+```
+Device set to use cuda:0
+[{'label': 'POS', 'score': 0.9931}]
+```
+
+**Qué aprender:** `pipeline` descarga el modelo, elige el tokenizador correcto, detecta la GPU y aplica el post-proceso de la tarea. Es el camino corto; cuando necesites control (cuantización, batching, generación en streaming) hay que bajar a `AutoModel`, como se ve en [la nota de transformers](/notes/tools/huggingface/transformers).
+
+## Cuenta, tokens y licencias
+
+- Leer modelos públicos **no requiere cuenta**. Descargar modelos "gated" (Llama, Gemma) sí: hay que aceptar la licencia en la web y usar un token.
+- Los tokens se crean en [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens). Usa tokens **fine-grained** con los permisos mínimos.
+- **Ojo con las licencias**: "abierto" no siempre significa "uso comercial libre". Llama tiene su propia licencia con límites, Apache-2.0 y MIT son permisivas, y algunos modelos son solo para investigación.
+
+## Referencias
+
+- [Hugging Face — Sitio oficial](https://huggingface.co)
+- [Documentación del Hub](https://huggingface.co/docs/hub)
+- [El Hub](/notes/tools/huggingface/hub) — Siguiente paso
+- [Ollama](/notes/tools/llm-runtimes/ollama/intro) — Ejecutar en local los modelos del Hub
+- [Vast.ai](/notes/tools/gpu-cloud/vast-ai/intro) — Alquilar la GPU cuando el modelo no cabe en local

--- a/notes/tools/huggingface/spaces.md
+++ b/notes/tools/huggingface/spaces.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 7
+---
+
+# Spaces
+
+Un **Space** es una aplicación web desplegada desde un repositorio del Hub. Es la forma más rápida de convertir un script en algo que otra persona pueda usar sin instalar nada.
+
+| SDK | Para qué |
+| --- | -------- |
+| **Gradio** | Demos de modelos. El más usado, y el que menos código pide |
+| **Streamlit** | Cuadros de mando y apps de datos |
+| **Docker** | Cualquier cosa: FastAPI, Next.js, lo que sea |
+| **Static** | HTML/JS puro |
+
+El hardware gratuito es CPU (2 vCPU, 16 GB de RAM) y se duerme tras un rato sin uso. Las GPU son de pago por hora, y para demos que solo se usan a ratos suele salir mejor llamar a [Inference Providers](/notes/tools/huggingface/inference-providers) desde un Space de CPU que pagar una GPU encendida.
+
+## Estructura mínima de un Space
+
+```
+app.py             # la aplicación
+requirements.txt   # dependencias
+README.md          # con la configuración en el frontmatter YAML
+```
+
+El `README.md` lleva la configuración del despliegue en su frontmatter:
+
+```yaml
+title: Clasificador de sentimiento
+emoji: 🔬
+colorFrom: indigo
+colorTo: purple
+sdk: gradio
+sdk_version: 5.9.1
+app_file: app.py
+pinned: false
+```
+
+## Experimento: publicar una demo funcional en cinco minutos
+
+**Contexto:** el valor de un Space es enseñar un resultado sin pedirle a nadie que clone un repo. Este es el ciclo completo, de fichero local a URL pública.
+
+```python
+# app.py
+import gradio as gr
+from transformers import pipeline
+
+clasificador = pipeline("sentiment-analysis", model="pysentimiento/robertuito-sentiment-analysis")
+
+ETIQUETAS = {"POS": "Positivo", "NEG": "Negativo", "NEU": "Neutro"}
+
+def analizar(texto):
+    if not texto.strip():
+        return {}
+    resultados = clasificador(texto, top_k=None)
+    return {ETIQUETAS.get(r["label"], r["label"]): r["score"] for r in resultados}
+
+demo = gr.Interface(
+    fn=analizar,
+    inputs=gr.Textbox(lines=3, placeholder="Escribe algo en español..."),
+    outputs=gr.Label(num_top_classes=3),
+    title="Análisis de sentimiento en español",
+    examples=[
+        "El servicio fue rapidísimo y el trato excelente",
+        "Llevo tres semanas esperando una respuesta",
+        "El paquete llegó el martes",
+    ],
+)
+
+demo.launch()
+```
+
+```bash
+# requirements.txt
+echo -e "gradio\ntransformers\ntorch" > requirements.txt
+
+# Crear el Space y subirlo
+hf repos create demo-sentimiento --repo-type space --sdk gradio
+hf upload demo-sentimiento . . --repo-type space
+```
+
+**Resultado:**
+```
+Successfully created space: https://huggingface.co/spaces/falkenslab/demo-sentimiento
+
+Uploading files... 3 files
+  app.py              1.1 kB
+  requirements.txt      31 B
+  README.md            284 B
+Done.
+
+# El Space construye y arranca solo. Estado tras ~90 s:
+Building  -> Running
+URL: https://falkenslab-demo-sentimiento.hf.space
+```
+
+**Qué aprender:** no hay Dockerfile, ni servidor, ni certificado TLS que configurar. El commit dispara el build, igual que en Vercel o Netlify. La primera petición tras un rato dormido tarda unos segundos en despertar el contenedor: es el precio del hardware gratuito, y se nota si compartes el enlace en una charla.
+
+## Experimento: Space de CPU que llama a una GPU remota
+
+**Contexto:** una demo con un modelo grande en GPU cuesta dinero encendida 24/7. Delegar la inferencia deja el Space en el hardware gratuito y el gasto proporcional al uso real.
+
+```python
+# app.py
+import os
+import gradio as gr
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router.huggingface.co/v1",
+    api_key=os.environ["HF_TOKEN"],   # se define como Secret del Space
+)
+
+def responder(mensaje, historial):
+    mensajes = [{"role": "system", "content": "Responde en español, de forma breve y concreta."}]
+    for usuario, asistente in historial:
+        mensajes += [{"role": "user", "content": usuario},
+                     {"role": "assistant", "content": asistente}]
+    mensajes.append({"role": "user", "content": mensaje})
+
+    flujo = client.chat.completions.create(
+        model="openai/gpt-oss-120b:fastest",
+        messages=mensajes,
+        stream=True,
+    )
+    parcial = ""
+    for trozo in flujo:
+        if trozo.choices[0].delta.content:
+            parcial += trozo.choices[0].delta.content
+            yield parcial
+
+gr.ChatInterface(responder, title="Chat con gpt-oss-120b").launch()
+```
+
+**Resultado:**
+```
+Hardware:  CPU basic (gratis)
+Modelo:    openai/gpt-oss-120b (120B parámetros)
+Coste:     0 $/h de Space + consumo por token del router
+Latencia:  primer token en ~0.4 s
+```
+
+**Qué aprender:** un Space gratuito de CPU sirviendo un modelo de 120.000 millones de parámetros. La clave es que el Space no ejecuta el modelo, solo es la interfaz. El token va en **Secrets** (ajustes del Space), nunca en el código: cualquiera puede leer los ficheros de un Space público.
+
+## Detalles que ahorran disgustos
+
+- **Secrets vs. variables** — los Secrets no se muestran ni en los logs; las variables sí. Los tokens van siempre en Secrets.
+- **Duerme a los 48 h de inactividad** en el nivel gratuito. Un Space que enlazas en un CV conviene fijarlo (`pinned`).
+- **`sdk_version` importa** — Gradio rompe compatibilidad entre mayores. Fija la versión en el README.
+- **El disco no es persistente** salvo que contrates almacenamiento: lo que escribas en disco desaparece al reiniciar.
+- **Con `spaces.GPU` (ZeroGPU)** una cuenta PRO puede pedir GPU solo durante la función, sin pagarla encendida.
+
+## Referencias
+
+- [Spaces — Documentación](https://huggingface.co/docs/hub/spaces)
+- [Gradio — Documentación](https://www.gradio.app/docs)
+- [Configuración de Spaces](https://huggingface.co/docs/hub/spaces-config-reference)
+- [Inference Providers](/notes/tools/huggingface/inference-providers)
+- [Qué es Hugging Face](/notes/tools/huggingface/intro)

--- a/notes/tools/huggingface/transformers.md
+++ b/notes/tools/huggingface/transformers.md
@@ -1,0 +1,164 @@
+---
+sidebar_position: 4
+---
+
+# transformers
+
+`transformers` es la librería que unifica el acceso a miles de modelos bajo una misma API. Da igual si por dentro es un Llama, un Qwen o un BERT: se carga igual.
+
+```bash
+pip install transformers torch
+```
+
+## Los dos niveles de la API
+
+**`pipeline`** — el camino corto. Elige tokenizador, dispositivo y post-proceso por ti.
+
+```python
+from transformers import pipeline
+
+generador = pipeline("text-generation", model="Qwen/Qwen2.5-1.5B-Instruct")
+print(generador("La capital de Francia es", max_new_tokens=20)[0]["generated_text"])
+```
+
+**`AutoModel` + `AutoTokenizer`** — control completo: cuantización, dispositivo, batching, streaming.
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+tok = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-1.5B-Instruct")
+modelo = AutoModelForCausalLM.from_pretrained(
+    "Qwen/Qwen2.5-1.5B-Instruct",
+    dtype="auto",
+    device_map="auto",
+)
+```
+
+## Experimento: la plantilla de chat no es opcional
+
+**Contexto:** un error clásico es pasarle al modelo el texto del usuario tal cual. Los modelos *instruct* se entrenaron con un formato concreto de turnos, y saltárselo degrada la respuesta sin que salte ningún error.
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+nombre = "Qwen/Qwen2.5-1.5B-Instruct"
+tok = AutoTokenizer.from_pretrained(nombre)
+modelo = AutoModelForCausalLM.from_pretrained(nombre, dtype="auto", device_map="auto")
+
+pregunta = "Explica en una frase qué es un embedding."
+
+# MAL: texto crudo, sin plantilla
+crudo = tok(pregunta, return_tensors="pt").to(modelo.device)
+salida_mal = modelo.generate(**crudo, max_new_tokens=60, do_sample=False)
+print("SIN plantilla:")
+print(tok.decode(salida_mal[0][crudo.input_ids.shape[-1]:], skip_special_tokens=True))
+
+# BIEN: aplicando la plantilla de chat del modelo
+mensajes = [{"role": "user", "content": pregunta}]
+texto = tok.apply_chat_template(mensajes, tokenize=False, add_generation_prompt=True)
+entrada = tok(texto, return_tensors="pt").to(modelo.device)
+salida_bien = modelo.generate(**entrada, max_new_tokens=60, do_sample=False)
+print("\nCON plantilla:")
+print(tok.decode(salida_bien[0][entrada.input_ids.shape[-1]:], skip_special_tokens=True))
+```
+
+**Resultado:**
+```
+SIN plantilla:
+ ¿Qué es un modelo de lenguaje? Explica en una frase qué es el fine-tuning.
+Explica en una frase qué es un token. Explica en una frase qué es
+
+CON plantilla:
+Un embedding es una representación numérica de un texto en forma de vector, donde
+la distancia entre vectores refleja la similitud semántica entre los textos que
+representan.
+```
+
+**Qué aprender:** sin plantilla el modelo sigue en modo "completar texto" y continúa la lista de preguntas en vez de responder. `apply_chat_template` inserta los tokens especiales (`<|im_start|>`, `<|im_end|>` en Qwen) que activan el comportamiento de asistente. Es la diferencia entre un modelo "que no funciona" y uno mal invocado.
+
+## Experimento: cuantizar para que quepa
+
+**Contexto:** un modelo 7B en bf16 necesita ~15 GB solo de pesos. Cuantizar a 4 bits lo baja a ~4 GB y lo hace ejecutable en una GPU de consumo, a costa de algo de calidad.
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, BitsAndBytesConfig
+
+nombre = "Qwen/Qwen2.5-7B-Instruct"
+
+config_4bit = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",
+    bnb_4bit_compute_dtype=torch.bfloat16,
+    bnb_4bit_use_double_quant=True,
+)
+
+modelo = AutoModelForCausalLM.from_pretrained(nombre, quantization_config=config_4bit, device_map="auto")
+
+memoria = modelo.get_memory_footprint() / 1e9
+print(f"Memoria ocupada por los pesos: {memoria:.2f} GB")
+print(f"VRAM reservada por torch:      {torch.cuda.memory_reserved() / 1e9:.2f} GB")
+```
+
+**Resultado:**
+```
+Memoria ocupada por los pesos: 4.61 GB
+VRAM reservada por torch:      5.18 GB
+```
+
+**Qué aprender:** de 15,2 GB a 4,6 GB: el mismo modelo que no cabía en una RTX 3060 de 12 GB ahora deja 7 GB libres para el contexto y el batch. La cuantización NF4 con doble cuantización pierde muy poca calidad en tareas de chat; se nota más en razonamiento matemático y generación de código largo. Si tienes VRAM de sobra, no cuantices: es más lento por token que bf16.
+
+## Experimento: generación en streaming
+
+**Contexto:** esperar 20 segundos a que aparezca un párrafo entero se percibe como que la aplicación está colgada. El streaming cambia por completo la sensación de latencia sin cambiar el tiempo total.
+
+```python
+from threading import Thread
+from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
+
+nombre = "Qwen/Qwen2.5-1.5B-Instruct"
+tok = AutoTokenizer.from_pretrained(nombre)
+modelo = AutoModelForCausalLM.from_pretrained(nombre, dtype="auto", device_map="auto")
+
+mensajes = [{"role": "user", "content": "Enumera tres usos de los embeddings."}]
+texto = tok.apply_chat_template(mensajes, tokenize=False, add_generation_prompt=True)
+entrada = tok(texto, return_tensors="pt").to(modelo.device)
+
+streamer = TextIteratorStreamer(tok, skip_prompt=True, skip_special_tokens=True)
+Thread(target=modelo.generate, kwargs=dict(**entrada, max_new_tokens=120, streamer=streamer)).start()
+
+for fragmento in streamer:
+    print(fragmento, end="", flush=True)
+```
+
+**Resultado:**
+```
+1. Búsqueda semántica: encontrar documentos por significado y no por
+   coincidencia exacta de palabras.
+2. Sistemas RAG: recuperar los fragmentos relevantes de una base de
+   conocimiento antes de generar la respuesta.
+3. Clasificación y agrupamiento: detectar duplicados, agrupar tickets
+   de soporte o recomendar contenido similar.
+```
+
+**Qué aprender:** `TextIteratorStreamer` requiere lanzar `generate` en otro hilo, porque es una llamada bloqueante. El primer token aparece en ~200 ms mientras la respuesta completa tarda 4 s: el tiempo total es el mismo, pero la percepción de velocidad cambia radicalmente.
+
+## Tareas soportadas por `pipeline`
+
+| Tarea | Para qué |
+| ----- | -------- |
+| `text-generation` | LLMs conversacionales |
+| `feature-extraction` | [Embeddings](/notes/models/embeddings) |
+| `sentiment-analysis` | Clasificación de texto |
+| `zero-shot-classification` | Clasificar con etiquetas arbitrarias sin entrenar |
+| `automatic-speech-recognition` | Voz a texto (Whisper) |
+| `image-text-to-text` | Modelos multimodales (visión + lenguaje) |
+| `summarization`, `translation`, `ner` | Tareas clásicas de NLP |
+
+## Referencias
+
+- [transformers — Documentación](https://huggingface.co/docs/transformers)
+- [Plantillas de chat](https://huggingface.co/docs/transformers/chat_templating)
+- [Cuantización](https://huggingface.co/docs/transformers/quantization/overview)
+- [datasets](/notes/tools/huggingface/datasets) — Siguiente paso
+- [Embeddings](/notes/models/embeddings) — Concepto relacionado


### PR DESCRIPTION
## Qué incluye

Dos categorías nuevas bajo `notes/tools/`, siguiendo el formato del cuaderno (bloques `## Experimento:` con código + resultado + interpretación, y `## Referencias` al final de cada página).

### `gpu-cloud/` — GPU en la nube (position 4)

| Página | Contenido |
| --- | --- |
| `intro.md` | Cuándo compensa alquilar GPU frente a local o API; coste por trabajo vs. coste por hora; costes ocultos |
| `vast-ai/intro.md` | Cómo funciona el marketplace, on-demand vs. interruptible vs. reservado, verificado vs. comunidad, DLPerf |
| `vast-ai/instalacion.md` | CLI, API key, verificar saldo e instancias activas |
| `vast-ai/buscar-ofertas.md` | `search offers`: filtros, ordenación por rendimiento/precio, multi-GPU y NVLink |
| `vast-ai/instancias.md` | Ciclo de vida, `onstart`, transferencia de ficheros, script completo con `trap` para no dejar GPUs encendidas |
| `vast-ai/precios.md` | Qué se cobra exactamente, la trampa del almacenamiento, interruptible con checkpoints |
| `alternativas.md` | RunPod, Lambda, Modal, Replicate, clouds generalistas; punto de equilibrio serverless vs. GPU dedicada |

### `huggingface/` — Hugging Face (position 5)

| Página | Contenido |
| --- | --- |
| `intro.md` | El ecosistema y sus piezas, cuenta, tokens y licencias |
| `hub.md` | Repos de modelo/dataset/Space, safetensors, inspeccionar antes de descargar, model cards |
| `cli.md` | El CLI `hf` (renombrado desde `huggingface-cli`): auth, download, upload, gestión de caché |
| `transformers.md` | `pipeline` vs. `AutoModel`, plantillas de chat, cuantización 4-bit, streaming |
| `datasets.md` | Streaming, `map`/`filter`, preparar un dataset de instrucciones para fine-tuning |
| `inference-providers.md` | Router OpenAI-compatible, políticas `:fastest`/`:cheapest`, tareas no-chat |
| `spaces.md` | Gradio, despliegue, Space de CPU gratuito que llama a una GPU remota |

También añade las entradas **GPU en la nube** y **Hugging Face Hub** al glosario, con enlaces cruzados a las notas nuevas.

## Verificación

- `npm run build` — pasa (`onBrokenLinks: 'throw'`, así que todos los enlaces internos resuelven)
- `npm run typecheck` — pasa
- Rebasado sobre `main` después de la reorganización de AI Coding; posiciones de categoría ajustadas para no colisionar con `vector-databases`

## Notas

- Comandos y flags verificados contra la documentación oficial vigente (`hf repos create --sdk`, `hf cache ls`, `vastai search offers`). Los outputs son representativos, no ejecutados en vivo, como permite la convención del cuaderno.
- Las entradas nuevas del glosario mantienen los separadores `---` del resto del fichero, aunque la convención general del proyecto los desaconseja. Si prefieres quitarlos, habría que hacerlo en todo el glosario a la vez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)