### PR TITLE
Add notes/CLAUDE.md and a /lint-notes command

### DIFF
--- a/.claude/commands/lint-notes.md
+++ b/.claude/commands/lint-notes.md
@@ -1,0 +1,83 @@
+Revisa la salud de la sección de notas del cuaderno y da un informe.
+
+Ámbito: "$ARGUMENTS" si se ha indicado algo (una ruta o subdirectorio de `notes/`); si está vacío, todo `notes/`.
+
+**Este comando NO arregla nada por su cuenta.** Genera el informe, muéstramelo agrupado por comprobación, y espera a que yo te diga qué arreglar. Solo aplica cambios si te los pido explícitamente.
+
+## 1. `## Referencias` al final
+
+Toda página debe terminar con una sección `## Referencias`.
+
+```bash
+for f in $(find notes -name "*.md" -not -name "CLAUDE.md" | sort); do
+  grep -q "^## Referencias" "$f" || echo "  $f"
+done
+```
+
+## 2. Separadores `---`
+
+Nunca se usa `---` como separador horizontal; se estructura con `##` y `###`. Hay que saltar el frontmatter, que usa la misma marca:
+
+```bash
+for f in $(find notes -name "*.md" -not -name "CLAUDE.md" | sort); do
+  n=$(awk 'NR==1 && $0=="---" {fm=1; next} fm==1 && /^---[[:space:]]*$/ {fm=2; next} (fm==2||fm==0) && /^---[[:space:]]*$/ {c++} END{print c+0}' "$f")
+  [ "$n" -gt 0 ] && echo "  $f ($n)"
+done
+```
+
+Nota: `notes/glossary.md` los usa a propósito para separar las secciones por letra, porque así lo indica el comando `/glossary`. Es un conflicto conocido con la norma general — repórtalo, pero no lo arregles sin preguntar.
+
+## 3. Enlaces internos
+
+Los enlaces internos rotos rompen el build (`onBrokenLinks: 'throw'`). Comprueba que cada ruta `/notes/...` referenciada corresponde a un fichero real:
+
+```bash
+grep -rhoE "\]\(/notes/[a-z0-9/-]+" notes experiments | sed 's/](//' | sort -u | while read -r l; do
+  [ -f "${l#/}.md" ] || echo "  ROTO: $l"
+done
+```
+
+Revisa además que ningún enlace interno incluya el base URL `/falkens-notebook` (Docusaurus lo añade solo) ni la extensión `.md`.
+
+## 4. Notas huérfanas
+
+Una nota sin enlaces entrantes solo es alcanzable desde la sidebar y en la práctica no se lee:
+
+```bash
+grep -rhoE "\]\(/notes/[a-z0-9/-]+" notes experiments | sed 's/](//' | sort -u > /tmp/lnk.txt
+for f in $(find notes -name "*.md" -not -name "CLAUDE.md" | sort); do
+  grep -qx "/${f%.md}" /tmp/lnk.txt || echo "  $f"
+done
+```
+
+Para cada huérfana, propón desde qué nota o experimento concreto tendría sentido enlazarla. No inventes enlaces forzados: si una nota no encaja en ningún sitio, dilo.
+
+## 5. Conceptos sin entrada en el glosario
+
+Busca términos técnicos que aparecen repetidamente en las notas y los experimentos pero no tienen entrada propia en `notes/glossary.md`. Lista los candidatos con el número de apariciones y en qué ficheros. Se añaden con `/glossary <término>`, no a mano.
+
+Comprueba también lo contrario: entradas del glosario que nadie enlaza nunca.
+
+## 6. Notas sin experimento
+
+Las notas deben incluir al menos un `## Experimento:` cuando sea posible:
+
+```bash
+for f in $(find notes -name "*.md" -not -name "CLAUDE.md" | sort); do
+  grep -q "^## Experimento" "$f" || echo "  $f"
+done
+```
+
+Esta lista siempre será larga y no todas son un problema: `intro.md`, `glossary.md` y las páginas de recursos no lo necesitan. Prioriza las notas de herramientas concretas, donde un experimento sí aportaría.
+
+## 7. Frontmatter
+
+Debe usar `sidebar_position`, no `position` (Docusaurus ignora este último). Cada directorio de la sidebar debe tener su `_category_.json`.
+
+## 8. Índice desactualizado
+
+Compara la lista de ficheros reales bajo `notes/` con el "Índice de notas" de `notes/CLAUDE.md`. Reporta las notas que falten en el índice y las entradas del índice que ya no existan.
+
+## Informe final
+
+Agrupa por comprobación, con recuento por cada una. Termina con las tres cosas que arreglaría primero y por qué, y espera mi confirmación.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ El sitio tiene dos secciones de contenido:
 - **Experimentos** (`experiments/`, ruta `/experiments`) — artículos/posts con experimentos concretos: código ejecutable, resultado real o representativo e interpretación breve. Son el corazón del cuaderno.
 - **Notas** (`notes/`, ruta `/notes`) — documentación de referencia organizada por tema: conceptos, modelos, herramientas. Aquí va la teoría, el glosario y el contexto que da soporte a los experimentos.
 
+**Al trabajar en `notes/`, lee primero `notes/CLAUDE.md`**: contiene la taxonomía de la sección, el formato de nota, las reglas de enlazado y el índice de las notas existentes.
+
 ## Commands
 
 ```bash

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -49,6 +49,15 @@ const config: Config = {
           path: './notes',
           routeBasePath: '/notes',
           sidebarPath: './sidebars.ts',
+          // CLAUDE.md son instrucciones para el agente, no contenido publicable.
+          // `exclude` sustituye a los patrones por defecto, así que se repiten aquí.
+          exclude: [
+            '**/_*.{js,jsx,ts,tsx,md,mdx}',
+            '**/_*/**',
+            '**/*.test.{js,jsx,ts,tsx}',
+            '**/__tests__/**',
+            '**/CLAUDE.md',
+          ],
           editUrl:
             'https://github.com/falkenslab/falkens-notebook/edit/main/',
         },

--- a/notes/CLAUDE.md
+++ b/notes/CLAUDE.md
@@ -1,0 +1,155 @@
+# CLAUDE.md — Notas
+
+Convenciones de la sección **Notas** (`notes/`, ruta pública `/notes`). Aplica a todo lo que hay bajo este directorio. Las normas generales del proyecto están en el `CLAUDE.md` de la raíz.
+
+## Qué es una nota
+
+Documentación de referencia: conceptos, guías de herramientas, modelos y contexto teórico que da soporte a los [experimentos](/experiments). La teoría vive aquí, no en los experimentos.
+
+Filosofía: **teoría la mínima indispensable**. Una nota existe para que se entienda mejor un experimento, no como fin en sí misma.
+
+## Taxonomía: dónde va cada cosa
+
+- **`basics/`** — Conceptos transversales que no dependen de ninguna herramienta concreta (prompt engineering, fundamentos).
+- **`models/`** — Familias y tipos de modelo: panorama general, embeddings, comparativas por proveedor.
+- **`tools/`** — Herramientas concretas. Tiene tres subárboles:
+  - `tools/agents/coding/<herramienta>/` — agentes de programación (Claude Code, Codex, opencode).
+  - `tools/agents/personal/<herramienta>/` — agentes de uso personal, no de programación (Hermes).
+  - `tools/llm-runtimes/<herramienta>/` — runtimes y aplicaciones para ejecutar modelos en local (Ollama, LM Studio, Jan, llamafile, Msty, AnythingLLM, Open WebUI).
+  - `tools/vector-databases/` — bases de datos vectoriales, un fichero por producto más `intro.md`.
+- **`resources/`** — Enlaces y catálogos de recursos externos.
+- **`glossary.md`** — Glosario único de todo el cuaderno. No se trocea en páginas por término.
+- **`intro.md`** — Portada de la sección.
+
+Criterio para herramientas con varias páginas: cuando una herramienta necesita más de una página, se le crea directorio propio con `_category_.json` y se reparte en las páginas habituales — `instalacion`, `configuracion`, `modelos`, `uso`, `comparativa`. Si con una página basta, un solo `overview.md` dentro de su directorio.
+
+## Formato de una nota
+
+Frontmatter mínimo — solo `sidebar_position` (no `position`, que Docusaurus ignora):
+
+```markdown
+---
+sidebar_position: 3
+---
+
+# Título de la nota
+
+Párrafo de entrada que dice qué es esto y por qué importa.
+```
+
+El cuerpo va con `##` y `###`. Después, cuando sea posible, un bloque de experimento con el formato del `CLAUDE.md` raíz. Siempre se cierra con `## Referencias`.
+
+## Enlazado
+
+Es lo que mantiene el cuaderno navegable, y es la regla que más se incumple.
+
+- **Rutas absolutas sin extensión ni base URL**: `/notes/tools/vector-databases/qdrant`, no `qdrant.md` ni `/falkens-notebook/notes/...`. Docusaurus añade el base URL solo.
+- **Al glosario, por ancla**: `[RAG](/notes/glossary#rag)`. El ancla es el texto del `###` en minúsculas, sin acentos, con guiones en lugar de espacios.
+- **Solo la primera mención** de un término en cada fichero se enlaza. Las siguientes van en texto plano.
+- **Toda nota nueva necesita al menos un enlace entrante** desde otra nota o desde un experimento. Una nota sin enlaces entrantes solo es alcanzable por la sidebar y en la práctica no se lee.
+- Los enlaces internos rotos **rompen el build** (`onBrokenLinks: 'throw'`).
+
+## `_category_.json`
+
+Cada directorio de la sidebar lleva el suyo:
+
+```json
+{
+  "label": "Nombre visible",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Una línea describiendo qué hay en esta sección."
+  }
+}
+```
+
+## Índice de notas
+
+Catálogo para decidir dónde encaja contenido nuevo sin abrir los 46 ficheros. Al añadir o renombrar una nota, actualiza también esta lista.
+
+### Raíz
+
+- `intro.md` — Portada de la sección: qué son las notas y su relación con los experimentos.
+- `glossary.md` — Glosario alfabético de conceptos de IA, con anclas enlazables desde todo el cuaderno.
+
+### `basics/`
+
+- `prompt-engineering.md` — Diseño y refinado de instrucciones para obtener mejores resultados de un modelo.
+
+### `models/`
+
+- `overview.md` — Panorama de modelos por tipo y proveedor.
+- `embeddings.md` — Modelos que convierten texto o imágenes en vectores semánticos; base de RAG y búsqueda.
+
+### `resources/`
+
+- `online-tools.md` — Aplicaciones web de IA usables desde el navegador, sin instalación.
+- `resources.md` — Lista de enlaces y recursos externos recomendados.
+
+### `tools/agents/coding/claude-code/`
+
+- `instalacion.md` — Qué es Claude Code (CLI de Anthropic) e instalación.
+- `claude-md.md` — El fichero `CLAUDE.md`, el directorio `.claude` y el comando `/init`.
+- `skills.md` — Skills y comandos personalizados.
+- `flujo-de-trabajo.md` — Flujo típico de trabajo con el agente.
+
+### `tools/agents/coding/codex/`
+
+- `instalacion.md` — Qué es Codex CLI (OpenAI) e instalación.
+- `agents-md.md` — `AGENTS.md`, el equivalente de `CLAUDE.md` en Codex.
+- `modelos.md` — Uso de cualquier proveedor compatible con la API de OpenAI.
+- `referencia.md` — Comandos útiles y comparativa.
+
+### `tools/agents/coding/opencode/`
+
+- `instalacion.md` — Agente de terminal open source (MIT) de Anomaly; instalación.
+- `configuracion.md` — Ficheros `opencode.json` / JSONC y su `$schema`.
+- `modelos.md` — Diseño agnóstico de proveedor: modelos remotos y locales.
+- `uso.md` — Sesión interactiva (TUI) y características.
+- `comparativa.md` — Ventajas, desventajas y comparación con Claude Code y Codex.
+
+### `tools/agents/personal/hermes/`
+
+- `instalacion.md` — Hermes Agent (Nous Research, MIT): agente personal, no de programación.
+- `configuracion.md` — Configuración YAML en `~/.hermes/`.
+- `modelos.md` — Más de 50 proveedores; la restricción real es el tamaño de modelo.
+- `uso.md` — Modos TUI y CLI.
+- `comparativa.md` — Por qué no compite con los agentes de programación.
+
+### `tools/llm-runtimes/`
+
+- `ollama/intro.md` — Qué es Ollama y por qué es la referencia para ejecutar LLMs en local.
+- `ollama/instalacion.md` — Instalación por sistema operativo.
+- `ollama/uso-basico.md` — Chat interactivo desde la terminal.
+- `ollama/modelos.md` — Catálogo, descarga y gestión de modelos.
+- `ollama/configuracion.md` — Variables de entorno y ajustes.
+- `ollama/api.md` — API REST compatible con OpenAI en `localhost:11434`.
+- `ollama/casos-de-uso.md` — Aplicaciones prácticas (asistente de código offline, etc.).
+- `lmstudio/overview.md` — App de escritorio para modelos GGUF con explorador integrado.
+- `jan/overview.md` — Alternativa open source a ChatGPT, 100% offline.
+- `llamafile/overview.md` — Modelo completo empaquetado en un único ejecutable portable (Mozilla).
+- `msty/overview.md` — App de escritorio todo-en-uno orientada a productividad.
+- `anythingllm/overview.md` — App todo-en-uno orientada a privacidad, escritorio o autoalojada.
+- `open-webui/overview.md` — Interfaz web tipo ChatGPT para Ollama, en local.
+
+### `tools/vector-databases/`
+
+- `intro.md` — Qué son y su papel como almacenamiento en sistemas RAG.
+- `chromadb.md` — La opción más simple para prototipos y proyectos pequeños.
+- `faiss.md` — Librería de búsqueda por similitud de Meta; motor dentro de otras bases de datos.
+- `pgvector.md` — Extensión de PostgreSQL con índices HNSW e IVFFlat.
+- `qdrant.md` — Open source en Rust, referencia para producción autoalojada.
+- `weaviate.md` — Objetos y vectores nativos; destaca en búsqueda híbrida.
+- `milvus.md` — Sistema distribuido para escala masiva.
+- `pinecone.md` — Servicio gestionado serverless que escala a cero.
+
+## Mantenimiento
+
+Pasa `/lint-notes` de vez en cuando, y siempre después de añadir varias notas seguidas. Comprueba `## Referencias`, separadores `---`, enlaces internos, notas huérfanas, conceptos sin entrada de glosario y notas sin experimento.
+
+## Referencias
+
+- [`CLAUDE.md` raíz](../CLAUDE.md) — Normas generales del proyecto y formato del bloque de experimento
+- [`.claude/commands/lint-notes.md`](../.claude/commands/lint-notes.md) — Comando de revisión de esta sección
+- [`.claude/commands/glossary.md`](../.claude/commands/glossary.md) — Comando para añadir términos al glosario


### PR DESCRIPTION
Adapta el patrón [LLM wiki de Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) a la sección de notas, quedándose con las piezas que encajan en un sitio publicado.

## Qué añade

- **`notes/CLAUDE.md`** — convenciones propias de la sección: taxonomía de directorios (dónde va cada nota nueva), formato de nota, reglas de enlazado y formato de `_category_.json`. Incluye un **índice de una línea por nota** para situar contenido nuevo sin abrir los 46 ficheros. Al ser anidado, solo se carga al trabajar bajo `notes/`.
- **`.claude/commands/lint-notes.md`** — comando `/lint-notes` con 8 comprobaciones: `## Referencias`, separadores `---`, enlaces internos rotos, notas huérfanas, conceptos sin entrada de glosario, notas sin experimento, frontmatter e índice desactualizado. **Solo informa**; no aplica cambios sin confirmación.
- **`docusaurus.config.ts`** — excluye `**/CLAUDE.md` de los docs. Sin esto, `notes/CLAUDE.md` se publicaría como página en `/notes` y aparecería en la sidebar. Se repiten los patrones `exclude` por defecto porque la opción los sustituye en lugar de ampliarlos.

## Descartado a propósito

`log.md` (git ya lo cubre), wiki-links `[[...]]` (Docusaurus no los renderiza), capa de fuentes crudas (no hay material que ingerir hoy) y trocear el glosario en una página por término (peor para lectores humanos).

## Deriva detectada en el primer pase

Medida sobre las 46 notas, **no arreglada en este PR**:

| Comprobación | Resultado |
|---|---|
| Sin `## Referencias` | 3: `glossary.md`, `models/overview.md`, `resources/resources.md` |
| Separadores `---` | 3 ficheros: `glossary.md` (17), `opencode/configuracion.md` (2), `opencode/uso.md` (2) |
| Enlaces internos rotos | 0 |
| Notas huérfanas | 16 |
| Sin `## Experimento:` | 31 (no todas son problema) |

Dos cosas que necesitan tu decisión:

1. **Conflicto de normas**: `/glossary` manda poner `---` entre secciones de letra, y el `CLAUDE.md` raíz los prohíbe. De ahí los 17 de `glossary.md`. Hay que decidir cuál gana y ajustar el otro fichero.
2. **`notes/resources/resources.md`** parece un resto de plantilla: sin `# ` de título, frontmatter con `position` en vez de `sidebar_position`, sin `## Referencias` y huérfana.

Nota menor: `.claude/commands/glossary.md` busca menciones en un directorio `ideas/` que no existe en el repo.

## Verificación

`npm ci && npm run build` pasa, y el build confirma que no se genera `build/notes/CLAUDE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
