### PR TITLE
Renombrar opencode a OpenCode en el texto

### DIFF
--- a/notes/CLAUDE.md
+++ b/notes/CLAUDE.md
@@ -13,7 +13,7 @@ Filosofía: **teoría la mínima indispensable**. Una nota existe para que se en
 - **`basics/`** — Conceptos transversales que no dependen de ninguna herramienta concreta (prompt engineering, fundamentos).
 - **`models/`** — Familias y tipos de modelo: panorama general, embeddings, comparativas por proveedor.
 - **`tools/`** — Herramientas concretas. Tiene tres subárboles:
-  - `tools/agents/coding/<herramienta>/` — agentes de programación (Claude Code, Codex, opencode).
+  - `tools/agents/coding/<herramienta>/` — agentes de programación (Claude Code, Codex, OpenCode).
   - `tools/agents/personal/<herramienta>/` — agentes de uso personal, no de programación (Hermes).
   - `tools/llm-runtimes/<herramienta>/` — runtimes y aplicaciones para ejecutar modelos en local (Ollama, LM Studio, Jan, llamafile, Msty, AnythingLLM, Open WebUI).
   - `tools/vector-databases/` — bases de datos vectoriales, un fichero por producto más `intro.md`.

--- a/notes/tools/agents/coding/opencode/_category_.json
+++ b/notes/tools/agents/coding/opencode/_category_.json
@@ -1,9 +1,9 @@
 {
-  "label": "opencode",
+  "label": "OpenCode",
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "Guía práctica de opencode: el agente de programación open source (MIT) que funciona en terminal con cualquier proveedor de modelos, incluidos modelos locales con Ollama."
+    "description": "Guía práctica de OpenCode: el agente de programación open source (MIT) que funciona en terminal con cualquier proveedor de modelos, incluidos modelos locales con Ollama."
   }
 }
 

--- a/notes/tools/agents/coding/opencode/comparativa.md
+++ b/notes/tools/agents/coding/opencode/comparativa.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Ventajas, desventajas y comparativa
 
-opencode compite en el mismo terreno que [Claude Code](/notes/tools/agents/coding/claude-code/instalacion) y [Codex CLI](/notes/tools/agents/coding/codex/instalacion): un agente que vive en la terminal, lee el repositorio, edita ficheros y ejecuta comandos. Lo que cambia es de quién depende y cuánto puedes tocar.
+OpenCode compite en el mismo terreno que [Claude Code](/notes/tools/agents/coding/claude-code/instalacion) y [Codex CLI](/notes/tools/agents/coding/codex/instalacion): un agente que vive en la terminal, lee el repositorio, edita ficheros y ejecuta comandos. Lo que cambia es de quién depende y cuánto puedes tocar.
 
 ## Ventajas
 
@@ -18,8 +18,8 @@ opencode compite en el mismo terreno que [Claude Code](/notes/tools/agents/codin
 
 ## Desventajas
 
-- **Calidad = calidad del modelo que le pongas.** Claude Code está afinado contra los modelos de Anthropic y Codex contra los de OpenAI; el prompt del sistema, la gestión de contexto y las herramientas están cocinados juntos. opencode tiene que ser genérico, y con el mismo modelo la diferencia se nota en tareas largas.
-- **Coste por API, sin suscripción plana.** Con Claude Code o Codex puedes trabajar dentro de una suscripción; aquí pagas tokens (salvo opencode Zen o modelos locales), y un agente consume muchos.
+- **Calidad = calidad del modelo que le pongas.** Claude Code está afinado contra los modelos de Anthropic y Codex contra los de OpenAI; el prompt del sistema, la gestión de contexto y las herramientas están cocinados juntos. OpenCode tiene que ser genérico, y con el mismo modelo la diferencia se nota en tareas largas.
+- **Coste por API, sin suscripción plana.** Con Claude Code o Codex puedes trabajar dentro de una suscripción; aquí pagas tokens (salvo OpenCode Zen o modelos locales), y un agente consume muchos.
 - **Ritmo de cambio alto.** Es un proyecto joven y muy activo: nombres de comandos y claves de configuración se mueven entre versiones. Fija la versión si automatizas en CI.
 - **Ecosistema más pequeño.** Menos plugins, menos plantillas de agentes y menos material escrito que alrededor de Claude Code.
 - **Windows algo menos pulido.** Funciona (Scoop, Chocolatey, npm) pero conviene fijar `"shell": "pwsh"` y esperar más fricción que en macOS o Linux.
@@ -27,7 +27,7 @@ opencode compite en el mismo terreno que [Claude Code](/notes/tools/agents/codin
 
 ## Comparativa
 
-| | **opencode** | **Claude Code** | **Codex CLI** |
+| | **OpenCode** | **Claude Code** | **Codex CLI** |
 |---|---|---|---|
 | Licencia | Open source (MIT) | Propietaria | Open source |
 | Fabricante | Anomaly | Anthropic | OpenAI |
@@ -45,7 +45,7 @@ opencode compite en el mismo terreno que [Claude Code](/notes/tools/agents/codin
 
 ## Cuándo usar cada uno
 
-- **opencode** — cuando el código no puede salir de tu red, cuando quieres elegir modelo por tarea, cuando necesitas ejecutar el motor en un servidor con GPU, o cuando la licencia abierta es un requisito.
+- **OpenCode** — cuando el código no puede salir de tu red, cuando quieres elegir modelo por tarea, cuando necesitas ejecutar el motor en un servidor con GPU, o cuando la licencia abierta es un requisito.
 - **Claude Code** — cuando quieres el mejor resultado posible con la menor configuración y ya pagas una suscripción de Anthropic.
 - **Codex CLI** — cuando tu equipo vive en el ecosistema de OpenAI.
 
@@ -53,7 +53,7 @@ No son excluyentes: comparten el concepto de fichero de reglas en la raíz del r
 
 ## Experimento: el mismo repo con dos agentes distintos
 
-**Contexto:** la comparativa de tabla vale poco sin verla. Aquí se lanza la misma tarea en el mismo repositorio con opencode (modelo remoto) y con Claude Code, en modo no interactivo, para comparar salida y coste.
+**Contexto:** la comparativa de tabla vale poco sin verla. Aquí se lanza la misma tarea en el mismo repositorio con OpenCode (modelo remoto) y con Claude Code, en modo no interactivo, para comparar salida y coste.
 
 ```bash
 cd falkens-notebook
@@ -66,7 +66,7 @@ claude -p "lista los ficheros de notes/ que no terminan con una sección '## Ref
 **Resultado:**
 
 ```
-# opencode  (anthropic/claude-sonnet-4-5)
+# OpenCode  (anthropic/claude-sonnet-4-5)
 $ grep -rL "## Referencias" notes --include=*.md
 notes/intro.md
 notes/tools/vector-databases/intro.md
@@ -86,9 +86,9 @@ Ambos son páginas índice; el resto de notas cumplen la convención.
 
 ## Referencias
 
-- [opencode — Sitio oficial](https://opencode.ai)
-- [opencode — Repositorio en GitHub](https://github.com/anomalyco/opencode)
+- [OpenCode — Sitio oficial](https://opencode.ai)
+- [OpenCode — Repositorio en GitHub](https://github.com/anomalyco/opencode)
 - [Claude Code — Documentación](https://docs.anthropic.com/es/docs/claude-code/overview)
 - [Codex CLI — Repositorio oficial](https://github.com/openai/codex)
-- [Instalación de opencode](/notes/tools/agents/coding/opencode/instalacion)
-- [Modelos remotos y locales en opencode](/notes/tools/agents/coding/opencode/modelos)
+- [Instalación de OpenCode](/notes/tools/agents/coding/opencode/instalacion)
+- [Modelos remotos y locales en OpenCode](/notes/tools/agents/coding/opencode/modelos)

--- a/notes/tools/agents/coding/opencode/configuracion.md
+++ b/notes/tools/agents/coding/opencode/configuracion.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Configuración
 
-Toda la configuración de opencode vive en ficheros `opencode.json` (también acepta JSONC, con comentarios). Empieza siempre por el `$schema`: da autocompletado y validación en el editor.
+Toda la configuración de OpenCode vive en ficheros `opencode.json` (también acepta JSONC, con comentarios). Empieza siempre por el `$schema`: da autocompletado y validación en el editor.
 
 ```json
 {
@@ -38,7 +38,7 @@ Lo habitual es dejar en el global el modelo, el tema y las claves personales, y 
 }
 ```
 
-`small_model` es el modelo barato que opencode usa para tareas auxiliares (títulos de sesión, resúmenes, compactación de contexto). Configurarlo bien es la optimización de coste más rentable.
+`small_model` es el modelo barato que OpenCode usa para tareas auxiliares (títulos de sesión, resúmenes, compactación de contexto). Configurarlo bien es la optimización de coste más rentable.
 
 ### Permisos y herramientas
 
@@ -127,7 +127,7 @@ Desde la CLI: `opencode mcp add`, `opencode mcp list`, `opencode mcp auth` (para
 }
 ```
 
-- `formatter` — opencode formatea automáticamente lo que edita si detecta el formateador del proyecto; aquí se desactiva o se personaliza.
+- `formatter` — OpenCode formatea automáticamente lo que edita si detecta el formateador del proyecto; aquí se desactiva o se personaliza.
 - `lsp` — usa los servidores de lenguaje para diagnósticos y navegación de símbolos.
 - `snapshot` — habilita los puntos de restauración de `/undo`.
 - `share` — `manual`, `auto` o `disabled`.
@@ -162,7 +162,7 @@ La apariencia va en un fichero aparte, `~/.config/opencode/tui.json`:
 
 ## Experimento: agente autónomo pero acotado en un repo
 
-**Contexto:** queremos que opencode itere solo sobre los tests sin pedir permiso a cada paso, pero sin poder tocar el historial de git ni borrar ficheros.
+**Contexto:** queremos que OpenCode itere solo sobre los tests sin pedir permiso a cada paso, pero sin poder tocar el historial de git ni borrar ficheros.
 
 `opencode.json` en la raíz del proyecto:
 
@@ -215,8 +215,8 @@ Permission required: git commit -m "fix(date): usar la zona horaria del usuario"
 
 ## Referencias
 
-- [opencode — Configuración](https://opencode.ai/docs/config/)
-- [opencode — Agentes](https://opencode.ai/docs/agents/)
-- [opencode — Permisos](https://opencode.ai/docs/permissions/)
-- [opencode — MCP](https://opencode.ai/docs/mcp-servers/)
+- [OpenCode — Configuración](https://opencode.ai/docs/config/)
+- [OpenCode — Agentes](https://opencode.ai/docs/agents/)
+- [OpenCode — Permisos](https://opencode.ai/docs/permissions/)
+- [OpenCode — MCP](https://opencode.ai/docs/mcp-servers/)
 - [Esquema JSON de configuración](https://opencode.ai/config.json)

--- a/notes/tools/agents/coding/opencode/instalacion.md
+++ b/notes/tools/agents/coding/opencode/instalacion.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Instalación
 
-**[opencode](https://opencode.ai)** es un agente de programación de terminal **open source (licencia MIT)**, mantenido por Anomaly. Hace lo mismo que [Claude Code](/notes/tools/agents/coding/claude-code/instalacion) o [Codex CLI](/notes/tools/agents/coding/codex/instalacion) —lee ficheros, edita código, ejecuta comandos, mantiene el contexto del proyecto— con una diferencia de diseño importante: **no está atado a ningún proveedor de modelos**. El mismo binario habla con Anthropic, OpenAI, Google, OpenRouter o con un modelo que corre en tu portátil bajo [Ollama](/notes/tools/llm-runtimes/ollama/instalacion).
+**[OpenCode](https://opencode.ai)** es un agente de programación de terminal **open source (licencia MIT)**, mantenido por Anomaly. Hace lo mismo que [Claude Code](/notes/tools/agents/coding/claude-code/instalacion) o [Codex CLI](/notes/tools/agents/coding/codex/instalacion) —lee ficheros, edita código, ejecuta comandos, mantiene el contexto del proyecto— con una diferencia de diseño importante: **no está atado a ningún proveedor de modelos**. El mismo binario habla con Anthropic, OpenAI, Google, OpenRouter o con un modelo que corre en tu portátil bajo [Ollama](/notes/tools/llm-runtimes/ollama/instalacion).
 
 Además del TUI de terminal, existe una aplicación de escritorio (beta) para macOS, Windows y Linux, y un modo servidor que separa el motor del cliente.
 
@@ -62,9 +62,9 @@ opencode auth login
 opencode auth list
 ```
 
-Si no quieres elegir proveedor todavía, **opencode Zen** es el catálogo curado del propio proyecto: modelos ya probados con el agente, con una sola clave.
+Si no quieres elegir proveedor todavía, **OpenCode Zen** es el catálogo curado del propio proyecto: modelos ya probados con el agente, con una sola clave.
 
-**2. Inicializar el proyecto.** El comando `/init` recorre el repositorio y genera un fichero `AGENTS.md` con las convenciones, comandos de build y arquitectura detectadas. Es el equivalente a `CLAUDE.md` en Claude Code o `AGENTS.md` en Codex —de hecho, opencode lee `CLAUDE.md` como *fallback* de compatibilidad.
+**2. Inicializar el proyecto.** El comando `/init` recorre el repositorio y genera un fichero `AGENTS.md` con las convenciones, comandos de build y arquitectura detectadas. Es el equivalente a `CLAUDE.md` en Claude Code o `AGENTS.md` en Codex —de hecho, OpenCode lee `CLAUDE.md` como *fallback* de compatibilidad.
 
 ## Experimento: instalar y ejecutar una tarea sin abrir el TUI
 
@@ -105,8 +105,8 @@ Sus dependencias principales son @docusaurus/core, @docusaurus/preset-classic y
 
 ## Referencias
 
-- [opencode — Sitio oficial](https://opencode.ai)
-- [opencode — Documentación](https://opencode.ai/docs/)
-- [opencode — Repositorio en GitHub](https://github.com/anomalyco/opencode)
+- [OpenCode — Sitio oficial](https://opencode.ai)
+- [OpenCode — Documentación](https://opencode.ai/docs/)
+- [OpenCode — Repositorio en GitHub](https://github.com/anomalyco/opencode)
 - [Instalación de Claude Code](/notes/tools/agents/coding/claude-code/instalacion)
 - [Instalación de Codex CLI](/notes/tools/agents/coding/codex/instalacion)

--- a/notes/tools/agents/coding/opencode/modelos.md
+++ b/notes/tools/agents/coding/opencode/modelos.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Modelos: remotos y locales
 
-Aquí está la diferencia real de opencode frente a Claude Code o Codex CLI: el agente es **agnóstico de proveedor** por diseño. La lógica del agente (herramientas, permisos, subagentes, contexto) es la misma tanto si detrás hay Claude Sonnet, GPT, Gemini o un `qwen2.5-coder` corriendo en tu máquina.
+Aquí está la diferencia real de OpenCode frente a Claude Code o Codex CLI: el agente es **agnóstico de proveedor** por diseño. La lógica del agente (herramientas, permisos, subagentes, contexto) es la misma tanto si detrás hay Claude Sonnet, GPT, Gemini o un `qwen2.5-coder` corriendo en tu máquina.
 
 ## Modelos remotos
 
@@ -17,7 +17,7 @@ opencode models         # todos los modelos disponibles
 opencode models anthropic --refresh
 ```
 
-Las credenciales se guardan en `~/.local/share/opencode/auth.json`. **opencode Zen** es el catálogo curado del proyecto: modelos ya validados con el agente y una única clave, pensado para no tener que abrir cuenta en cada proveedor.
+Las credenciales se guardan en `~/.local/share/opencode/auth.json`. **OpenCode Zen** es el catálogo curado del proyecto: modelos ya validados con el agente y una única clave, pensado para no tener que abrir cuenta en cada proveedor.
 
 ### Elegir modelo
 
@@ -126,16 +126,16 @@ ollama serve
 ```
 
 :::tip
-Declara siempre `limit.context`: sin ese dato opencode no sabe cuándo compactar la conversación y el modelo local empieza a truncar en silencio a mitad de tarea.
+Declara siempre `limit.context`: sin ese dato OpenCode no sabe cuándo compactar la conversación y el modelo local empieza a truncar en silencio a mitad de tarea.
 :::
 
 :::warning
 Un agente de código no solo genera texto: encadena llamadas a herramientas (`read`, `edit`, `bash`) en formato estructurado. Los modelos pequeños fallan justamente ahí. Por debajo de 14B con *tool calling* decente la experiencia es frustrante: el agente lee ficheros pero no consigue aplicar ediciones. `qwen2.5-coder:14b/32b` y `devstral` son los que mejor aguantan hoy.
 :::
 
-## Experimento: opencode con Ollama, sin salir de la máquina
+## Experimento: OpenCode con Ollama, sin salir de la máquina
 
-**Contexto:** en un proyecto con código que no puede salir de la red interna, la pregunta no es si opencode *puede* usar un modelo local, sino si el bucle de agente (leer → editar → verificar) sigue funcionando sin API remota.
+**Contexto:** en un proyecto con código que no puede salir de la red interna, la pregunta no es si OpenCode *puede* usar un modelo local, sino si el bucle de agente (leer → editar → verificar) sigue funcionando sin API remota.
 
 ```bash
 ollama pull qwen2.5-coder:14b
@@ -205,12 +205,12 @@ Las salidas de este experimento son **representativas**, no ejecutadas en vivo: 
 
 ## Referencias
 
-- [opencode — Proveedores](https://opencode.ai/docs/providers/)
-- [opencode — Modelos](https://opencode.ai/docs/models/)
-- [opencode Zen](https://opencode.ai/docs/zen/)
+- [OpenCode — Proveedores](https://opencode.ai/docs/providers/)
+- [OpenCode — Modelos](https://opencode.ai/docs/models/)
+- [OpenCode Zen](https://opencode.ai/docs/zen/)
 - [Ollama — Sitio oficial](https://ollama.com)
 - [Modelos disponibles en Ollama](https://ollama.com/library)
 - [Instalación de Ollama](/notes/tools/llm-runtimes/ollama/instalacion)
 - [LM Studio](/notes/tools/llm-runtimes/lmstudio/overview)
 - [Modelos y proveedores en Codex CLI](/notes/tools/agents/coding/codex/modelos)
-- [Issue #9 — Ejecutar en real los experimentos de opencode](https://github.com/falkenslab/falkens-notebook/issues/9)
+- [Issue #9 — Ejecutar en real los experimentos de OpenCode](https://github.com/falkenslab/falkens-notebook/issues/9)

--- a/notes/tools/agents/coding/opencode/uso.md
+++ b/notes/tools/agents/coding/opencode/uso.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Uso y características
 
-opencode abre una sesión interactiva en la terminal (TUI). Escribes en lenguaje natural lo que quieres y el agente lee ficheros, propone cambios, los aplica y ejecuta comandos según los permisos configurados.
+OpenCode abre una sesión interactiva en la terminal (TUI). Escribes en lenguaje natural lo que quieres y el agente lee ficheros, propone cambios, los aplica y ejecuta comandos según los permisos configurados.
 
 ```
 > añade validación al formulario de login para que el email sea obligatorio
@@ -12,7 +12,7 @@ opencode abre una sesión interactiva en la terminal (TUI). Escribes en lenguaje
 
 ## Agentes: Build y Plan
 
-La característica más visible de opencode es que trabaja con **agentes** conmutables con la tecla `Tab`:
+La característica más visible de OpenCode es que trabaja con **agentes** conmutables con la tecla `Tab`:
 
 | Agente | Tipo | Para qué sirve |
 |---|---|---|
@@ -35,7 +35,7 @@ Hay además tres agentes internos ocultos que se encargan de compactar el contex
 
 Comandos integrados: `/init`, `/connect`, `/models`, `/undo`, `/redo`, `/share`, `/help`.
 
-`/undo` y `/redo` son especialmente prácticos: opencode toma *snapshots* del árbol de trabajo, así que puedes revertir lo que ha hecho el agente sin depender de git.
+`/undo` y `/redo` son especialmente prácticos: OpenCode toma *snapshots* del árbol de trabajo, así que puedes revertir lo que ha hecho el agente sin depender de git.
 
 ### Comandos personalizados
 
@@ -75,7 +75,7 @@ Para trocear las reglas en varios ficheros, la clave `instructions` de `opencode
 
 ## Modo headless, servidor y web
 
-opencode separa motor y cliente, algo que lo diferencia del resto de agentes de terminal:
+OpenCode separa motor y cliente, algo que lo diferencia del resto de agentes de terminal:
 
 ```bash
 opencode run "corrige el lint de src/"        # no interactivo, para scripts y CI
@@ -101,7 +101,7 @@ El comando `/share` genera un enlace público con la conversación —muy cómod
 
 ## Experimento: plan primero, build después
 
-**Contexto:** el error más común al usar un agente es dejarle editar antes de haber acordado el enfoque. El modo `plan` de opencode fuerza ese paso sin necesidad de configurar nada.
+**Contexto:** el error más común al usar un agente es dejarle editar antes de haber acordado el enfoque. El modo `plan` de OpenCode fuerza ese paso sin necesidad de configurar nada.
 
 ```bash
 cd falkens-notebook
@@ -140,9 +140,9 @@ Pulsa Tab para cambiar a build y aplicar el plan.
 
 ## Referencias
 
-- [opencode — Agentes](https://opencode.ai/docs/agents/)
-- [opencode — Comandos personalizados](https://opencode.ai/docs/commands/)
-- [opencode — AGENTS.md](https://opencode.ai/docs/rules/)
-- [opencode — CLI](https://opencode.ai/docs/cli/)
+- [OpenCode — Agentes](https://opencode.ai/docs/agents/)
+- [OpenCode — Comandos personalizados](https://opencode.ai/docs/commands/)
+- [OpenCode — AGENTS.md](https://opencode.ai/docs/rules/)
+- [OpenCode — CLI](https://opencode.ai/docs/cli/)
 - [CLAUDE.md en Claude Code](/notes/tools/agents/coding/claude-code/claude-md)
 - [AGENTS.md en Codex CLI](/notes/tools/agents/coding/codex/agents-md)

--- a/notes/tools/agents/personal/hermes/comparativa.md
+++ b/notes/tools/agents/personal/hermes/comparativa.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Ventajas, desventajas y comparativa
 
-Hermes aparece en esta sección junto a Claude Code, Codex CLI y opencode, pero **no compite con ellos**. Conviene entender dónde se solapan de verdad antes de elegir.
+Hermes aparece en esta sección junto a Claude Code, Codex CLI y OpenCode, pero **no compite con ellos**. Conviene entender dónde se solapan de verdad antes de elegir.
 
 ## El solape real
 
@@ -43,7 +43,7 @@ Lo que no comparte, y define su categoría:
 
 ## Comparativa
 
-| | **Hermes Agent** | **opencode** | **Claude Code** | **Codex CLI** |
+| | **Hermes Agent** | **OpenCode** | **Claude Code** | **Codex CLI** |
 |---|---|---|---|---|
 | Categoría | Agente personal | Agente de programación | Agente de programación | Agente de programación |
 | Licencia | Open source (MIT) | Open source (MIT) | Propietaria | Open source |
@@ -63,7 +63,7 @@ Lo que no comparte, y define su categoría:
 ## Cuándo usar cada uno
 
 - **Hermes** — cuando quieres un agente que *persista*: que recuerde tus proyectos, ejecute tareas programadas y esté disponible desde el móvil. Tareas de operación, informes, automatización doméstica o de infraestructura.
-- **opencode** — cuando el trabajo es código y necesitas elegir el modelo, incluido uno local. Ver [su comparativa](/notes/tools/agents/coding/opencode/comparativa).
+- **OpenCode** — cuando el trabajo es código y necesitas elegir el modelo, incluido uno local. Ver [su comparativa](/notes/tools/agents/coding/opencode/comparativa).
 - **Claude Code** — cuando quieres el mejor resultado en código con la mínima configuración.
 - **Codex CLI** — cuando tu equipo vive en el ecosistema de OpenAI.
 
@@ -86,7 +86,7 @@ hermes
 **Resultado:**
 
 ```
-# opencode
+# OpenCode
 $ grep -rL "## Referencias" notes --include=*.md
 notes/intro.md
 notes/tools/vector-databases/intro.md
@@ -110,7 +110,7 @@ Done in 22s
 2 notas sin referencias. Te aviso los lunes si aparecen nuevas.
 ```
 
-**Qué aprender:** la primera mitad de la tarea la resuelven igual —un `grep`—. La segunda mitad, "avísame cada lunes", opencode ni siquiera la contempla, porque no es lo suyo. Y Hermes, además de programar el cron, guardó el procedimiento como skill para reutilizarlo. Ahí está la frontera entre las dos categorías.
+**Qué aprender:** la primera mitad de la tarea la resuelven igual —un `grep`—. La segunda mitad, "avísame cada lunes", OpenCode ni siquiera la contempla, porque no es lo suyo. Y Hermes, además de programar el cron, guardó el procedimiento como skill para reutilizarlo. Ahí está la frontera entre las dos categorías.
 
 :::note
 Salidas representativas, no ejecutadas en vivo.
@@ -121,6 +121,6 @@ Salidas representativas, no ejecutadas en vivo.
 - [Hermes Agent — Sitio oficial](https://hermes-agent.nousresearch.com/)
 - [Hermes Agent — Repositorio en GitHub](https://github.com/NousResearch/hermes-agent)
 - [Nous Research](https://nousresearch.com)
-- [Ventajas, desventajas y comparativa de opencode](/notes/tools/agents/coding/opencode/comparativa)
+- [Ventajas, desventajas y comparativa de OpenCode](/notes/tools/agents/coding/opencode/comparativa)
 - [Claude Code — Documentación](https://docs.anthropic.com/es/docs/claude-code/overview)
 - [Codex CLI — Repositorio oficial](https://github.com/openai/codex)

--- a/notes/tools/agents/personal/hermes/configuracion.md
+++ b/notes/tools/agents/personal/hermes/configuracion.md
@@ -133,7 +133,7 @@ display:
 
 ## Servidores MCP
 
-Hermes se conecta a servidores [MCP](https://modelcontextprotocol.io) para sumar herramientas externas, igual que opencode o Claude Code. Se declaran en la sección correspondiente de `config.yaml`.
+Hermes se conecta a servidores [MCP](https://modelcontextprotocol.io) para sumar herramientas externas, igual que OpenCode o Claude Code. Se declaran en la sección correspondiente de `config.yaml`.
 
 ## Experimento: acotar el agente antes de soltarlo
 
@@ -199,4 +199,4 @@ Salidas representativas, no ejecutadas en vivo: reproducen el formato y comporta
 - [`cli-config.yaml.example` en el repositorio](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example)
 - [Model Context Protocol](https://modelcontextprotocol.io)
 - [Modelos remotos y locales en Hermes](/notes/tools/agents/personal/hermes/modelos)
-- [Configuración de opencode](/notes/tools/agents/coding/opencode/configuracion)
+- [Configuración de OpenCode](/notes/tools/agents/coding/opencode/configuracion)

--- a/notes/tools/agents/personal/hermes/instalacion.md
+++ b/notes/tools/agents/personal/hermes/instalacion.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 **[Hermes Agent](https://hermes-agent.nousresearch.com/)** es el agente open source (licencia MIT) de [Nous Research](https://nousresearch.com). Vive en esta sección porque ejecuta comandos, edita ficheros y trabaja sobre repositorios, pero conviene situarlo bien desde el principio.
 
 :::info Qué es y qué no es
-Hermes **no es un agente de programación** en el sentido de [Claude Code](/notes/tools/agents/coding/claude-code/instalacion), [Codex CLI](/notes/tools/agents/coding/codex/instalacion) u [opencode](/notes/tools/agents/coding/opencode/instalacion). Es un **agente personal persistente**: memoria de largo plazo entre sesiones, creación automática de *skills* reutilizables, planificador cron propio y conectores a Telegram, Discord, Slack, WhatsApp y Signal. Programar es una de las cosas que sabe hacer, no su razón de ser. La [comparativa](/notes/tools/agents/personal/hermes/comparativa) desarrolla dónde se solapa realmente con los agentes de código y dónde no.
+Hermes **no es un agente de programación** en el sentido de [Claude Code](/notes/tools/agents/coding/claude-code/instalacion), [Codex CLI](/notes/tools/agents/coding/codex/instalacion) u [OpenCode](/notes/tools/agents/coding/opencode/instalacion). Es un **agente personal persistente**: memoria de largo plazo entre sesiones, creación automática de *skills* reutilizables, planificador cron propio y conectores a Telegram, Discord, Slack, WhatsApp y Signal. Programar es una de las cosas que sabe hacer, no su razón de ser. La [comparativa](/notes/tools/agents/personal/hermes/comparativa) desarrolla dónde se solapa realmente con los agentes de código y dónde no.
 :::
 
 :::warning Cuidado con los dominios
@@ -104,4 +104,4 @@ Las salidas de los experimentos de esta sección son **representativas**: reflej
 - [Hermes Agent — Repositorio en GitHub](https://github.com/NousResearch/hermes-agent)
 - [Nous Research](https://nousresearch.com)
 - [Nous Portal](https://portal.nousresearch.com)
-- [Instalación de opencode](/notes/tools/agents/coding/opencode/instalacion)
+- [Instalación de OpenCode](/notes/tools/agents/coding/opencode/instalacion)

--- a/notes/tools/agents/personal/hermes/modelos.md
+++ b/notes/tools/agents/personal/hermes/modelos.md
@@ -211,4 +211,4 @@ Salidas representativas, no ejecutadas en vivo. La cifra exacta de tokens del pr
 - [Instalación de Ollama](/notes/tools/llm-runtimes/ollama/instalacion)
 - [Modelfiles en Ollama](/notes/tools/llm-runtimes/ollama/modelos)
 - [LM Studio](/notes/tools/llm-runtimes/lmstudio/overview)
-- [Modelos remotos y locales en opencode](/notes/tools/agents/coding/opencode/modelos)
+- [Modelos remotos y locales en OpenCode](/notes/tools/agents/coding/opencode/modelos)


### PR DESCRIPTION
Cambia la grafía `opencode` por **OpenCode** en el texto de las notas. Rehecho desde el `main` actual (sustituye al #11, que quedó en conflicto tras la reorganización a `notes/tools/agents/`).

## Qué cambia

- Cuerpo de texto, cabeceras de tabla comparativa, etiquetas de enlace y `## Referencias`.
- Etiqueta y descripción de la categoría en la barra lateral (`_category_.json`).
- Menciones en las notas de Hermes que enlazan a la sección.
- Rótulos de salida representativa donde `# opencode` actuaba como etiqueta frente a `# Claude Code` / `# Hermes`.
- La mención en el índice de `notes/CLAUDE.md`.

## Qué NO cambia (a propósito)

Todo lo que es identificador técnico y rompería si se cambiase:

- Comandos: `opencode run`, `opencode auth login`, `opencode serve`...
- Ficheros y rutas: `opencode.json`, `.opencode/`, `~/.config/opencode/`, `~/.local/share/opencode/auth.json`
- Paquetes e imágenes: `opencode-ai`, `anomalyco/tap/opencode`, `ghcr.io/anomalyco/opencode`
- URLs (`https://opencode.ai/...`) y rutas internas del sitio (`/notes/tools/agents/coding/opencode/...`)
- Salida literal de la CLI: `opencode 0.15.3`, `● opencode Zen (recommended)`

## Verificación

- 57 líneas cambiadas, todas sustituciones 1:1.
- Comprobado que no queda ningún `opencode` en minúscula en prosa (fuera de bloques de código, `backticks` y destinos de enlace).
- `npm run build` pasa. Como el sitio está configurado con `onBrokenLinks: 'throw'`, la build confirma que ningún enlace interno se ha roto.

Nota: la marca oficial del proyecto se estiliza en minúscula (`opencode`), por si prefieres descartarlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)